### PR TITLE
Add memory compiler to macros

### DIFF
--- a/macros/src/main/scala/MacroCompiler.scala
+++ b/macros/src/main/scala/MacroCompiler.scala
@@ -68,7 +68,7 @@ object MacroCompilerAnnotation {
    * @param costMetric Cost metric to use
    * @param mode Compiler mode (see CompilerMode)
    */
-  case class Params(mem: String, lib: Option[String], costMetric: CostMetric, mode: CompilerMode)
+  case class Params(mem: String, lib: Option[String], costMetric: CostMetric, mode: CompilerMode, useCompiler: Boolean)
 
   /**
    * Create a MacroCompilerAnnotation.
@@ -121,15 +121,15 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
       for ((memPort, libPort) <- pairedPorts) {
 
         // Make sure we don't have a maskGran larger than the width of the memory.
-        assert (memPort.src.effectiveMaskGran <= memPort.src.width)
-        assert (libPort.src.effectiveMaskGran <= libPort.src.width)
+        assert (memPort.src.effectiveMaskGran <= memPort.src.width.get)
+        assert (libPort.src.effectiveMaskGran <= libPort.src.width.get)
 
-        val libWidth = libPort.src.width
+        val libWidth = libPort.src.width.get
 
         // Don't consider cases of maskGran == width as "masked" since those masks
         // effectively function as write-enable bits.
-        val memMask = if (memPort.src.effectiveMaskGran == memPort.src.width) None else memPort.src.maskGran
-        val libMask = if (libPort.src.effectiveMaskGran == libPort.src.width) None else libPort.src.maskGran
+        val memMask = if (memPort.src.effectiveMaskGran == memPort.src.width.get) None else memPort.src.maskGran
+        val libMask = if (libPort.src.effectiveMaskGran == libPort.src.width.get) None else libPort.src.maskGran
 
         (memMask, libMask) match {
           // Neither lib nor mem is masked.
@@ -142,12 +142,12 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
 
           // Only the mem is masked.
           case (Some(p), None) => {
-            if (p % libPort.src.width == 0) {
+            if (p % libPort.src.width.get == 0) {
               // If the mem mask is a multiple of the lib width, then we're good.
               // Just roll over every lib width as usual.
               // e.g. lib width=4, mem maskGran={4, 8, 12, 16, ...}
               splitMemory(libWidth)
-            } else if (libPort.src.width % p == 0) {
+            } else if (libPort.src.width.get % p == 0) {
               // Lib width is a multiple of the mem mask.
               // Consider the case where mem mask = 4 but lib width = 8, unmasked.
               // We can still compile, but will need to waste the extra bits.
@@ -155,13 +155,13 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
             } else {
               // No neat multiples.
               // We might still be able to compile extremely inefficiently.
-              if (p < libPort.src.width) {
+              if (p < libPort.src.width.get) {
                 // Compile using mem mask as the effective width. (note that lib is not masked)
                 // e.g. mem mask = 3, lib width = 8
                 splitMemory(memMask.get)
               } else {
                 // e.g. mem mask = 13, lib width = 8
-                System.err.println(s"Unmasked target memory: unaligned mem maskGran ${p} with lib (${lib.src.name}) width ${libPort.src.width} not supported")
+                System.err.println(s"Unmasked target memory: unaligned mem maskGran ${p} with lib (${lib.src.name}) width ${libPort.src.width.get} not supported")
                 return None
               }
             }
@@ -343,13 +343,13 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
             case Some(PolarizedPort(mem, _)) =>
               /* Palmer: The bits from the outer memory's write mask that will be
                * used as the write mask for this inner memory. */
-              if (libPort.src.effectiveMaskGran == libPort.src.width) {
+              if (libPort.src.effectiveMaskGran == libPort.src.width.get) {
                 bits(WRef(mem), low / memPort.src.effectiveMaskGran)
               } else {
                 require(isPowerOfTwo(libPort.src.effectiveMaskGran), "only powers of two masks supported for now")
 
-                val effectiveLibWidth = if (memPort.src.maskGran.get < libPort.src.effectiveMaskGran) memPort.src.maskGran.get else libPort.src.width
-                cat(((0 until libPort.src.width by libPort.src.effectiveMaskGran) map (i => {
+                val effectiveLibWidth = if (memPort.src.maskGran.get < libPort.src.effectiveMaskGran) memPort.src.maskGran.get else libPort.src.width.get
+                cat(((0 until libPort.src.width.get by libPort.src.effectiveMaskGran) map (i => {
                   if (memPort.src.maskGran.get < libPort.src.effectiveMaskGran && i >= effectiveLibWidth) {
                     // If the memMaskGran is smaller than the lib's gran, then
                     // zero out the upper bits.
@@ -363,7 +363,7 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
               /* If there is a lib mask port but no mem mask port, just turn on
                * all bits of the lib mask port. */
               if (libPort.src.maskPort.isDefined) {
-                val width = libPort.src.width / libPort.src.effectiveMaskGran
+                val width = libPort.src.width.get / libPort.src.effectiveMaskGran
                 val value = (BigInt(1) << width.toInt) - 1
                 UIntLiteral(value, IntWidth(width))
               } else {
@@ -490,7 +490,7 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
             // Run the cost function to evaluate this potential compile.
             costMetric.cost(mem, lib) match {
               case Some(newCost) => {
-                System.err.println(s"Cost of ${lib.src.name} for ${mem.src.name}: ${newCost}")
+                //System.err.println(s"Cost of ${lib.src.name} for ${mem.src.name}: ${newCost}")
                 // Try compiling
                 compile(mem, lib) match {
                   // If it was successful and the new cost is lower
@@ -526,7 +526,7 @@ class MacroCompilerTransform extends Transform {
   def inputForm = MidForm
   def outputForm = MidForm
   def execute(state: CircuitState) = getMyAnnotations(state) match {
-    case Seq(MacroCompilerAnnotation(state.circuit.main, MacroCompilerAnnotation.Params(memFile, libFile, costMetric, mode))) =>
+    case Seq(MacroCompilerAnnotation(state.circuit.main, MacroCompilerAnnotation.Params(memFile, libFile, costMetric, mode, useCompiler))) =>
       if (mode == MacroCompilerAnnotation.FallbackSynflops) {
         throw new UnsupportedOperationException("Not implemented yet")
       }
@@ -538,7 +538,10 @@ class MacroCompilerTransform extends Transform {
       }
       val libs: Option[Seq[Macro]] = mdf.macrolib.Utils.readMDFFromPath(libFile) match {
         case Some(x:Seq[mdf.macrolib.Macro]) =>
-          Some(Utils.filterForSRAM(Some(x)) getOrElse(List()) map {new Macro(_)})
+          if(useCompiler){
+            findSRAMCompiler(Some(x)).map{x => buildSRAMMacros(x).map(new Macro(_)) }
+          }
+          else Some(Utils.filterForSRAM(Some(x)) getOrElse(List()) map {new Macro(_)})
         case _ => None
       }
       val transforms = Seq(
@@ -578,12 +581,14 @@ object MacroCompiler extends App {
   case object Verilog extends MacroParam
   case object CostFunc extends MacroParam
   case object Mode extends MacroParam
+  case object UseCompiler extends MacroParam
   type MacroParamMap = Map[MacroParam, String]
   type CostParamMap = Map[String, String]
   val usage = Seq(
     "Options:",
     "  -m, --macro-list: The set of macros to compile",
     "  -l, --library: The set of macros that have blackbox instances",
+    "  -u, --use-compiler: Flag, whether to use the memory compiler defined in library",
     "  -v, --verilog: Verilog output",
     "  -c, --cost-func: Cost function to use. Optional (default: \"default\")",
     "  -cp, --cost-param: Cost function parameter. (Optional depending on the cost function.). e.g. -c ExternalMetric -cp path /path/to/my/cost/script",
@@ -601,6 +606,8 @@ object MacroCompiler extends App {
         parseArgs(map + (Macros  -> value), costMap, tail)
       case ("-l" | "--library") :: value :: tail =>
         parseArgs(map + (Library -> value), costMap, tail)
+      case ("-u" | "--use-compiler") :: tail =>
+        parseArgs(map + (UseCompiler -> ""), costMap, tail)
       case ("-v" | "--verilog") :: value :: tail =>
         parseArgs(map + (Verilog -> value), costMap, tail)
       case ("-c" | "--cost-func") :: value :: tail =>
@@ -633,7 +640,8 @@ object MacroCompiler extends App {
             MacroCompilerAnnotation.Params(
               params.get(Macros).get, params.get(Library),
               CostMetric.getCostMetric(params.getOrElse(CostFunc, "default"), costParams),
-              MacroCompilerAnnotation.stringToCompilerMode(params.getOrElse(Mode, "default"))
+              MacroCompilerAnnotation.stringToCompilerMode(params.getOrElse(Mode, "default")),
+              params.contains(UseCompiler)
             )
           ))
         )
@@ -650,6 +658,7 @@ object MacroCompiler extends App {
       verilogWriter.close()
     } catch {
       case e: java.util.NoSuchElementException =>
+        e.printStackTrace()
         println(usage)
         sys.exit(1)
       case e: MacroCompilerException =>

--- a/macros/src/test/scala/MacroCompilerSpec.scala
+++ b/macros/src/test/scala/MacroCompilerSpec.scala
@@ -197,8 +197,8 @@ trait HasSRAMGenerator {
   // 'vt': ('svt','lvt','ulvt'), 'mux': 4,  'depth': range(32,1025,16),     'width': range(4,145),     'ports': 1}
   def generateSRAMCompiler(name: String, prefix: String): mdf.macrolib.SRAMCompiler = {
     SRAMCompiler(name, Seq(
-      generateSimpleSRAMGroup(prefix, 2, Range(16, 513, 8), Range(8, 289, 2)),
-      generateSimpleSRAMGroup(prefix, 4, Range(32, 1025, 16), Range(4, 145, 1))
+      generateSimpleSRAMGroup(prefix, 2, Range(16, 512, 8), Range(8, 288, 2)),
+      generateSimpleSRAMGroup(prefix, 4, Range(32, 1024, 16), Range(4, 144, 1))
     ))
   }
 }

--- a/macros/src/test/scala/MacroCompilerSpec.scala
+++ b/macros/src/test/scala/MacroCompilerSpec.scala
@@ -126,15 +126,15 @@ trait HasSRAMGenerator {
   // Generate a standard (read/write/combo) port for testing.
   // Helper methods for optional width argument
   def generateTestPort(
-                        prefix: String,
-                        width: Option[Int],
-                        depth: Option[Int],
-                        maskGran: Option[Int] = None,
-                        read: Boolean,
-                        readEnable: Boolean = false,
-                        write: Boolean,
-                        writeEnable: Boolean = false
-                      ): MacroPort = {
+    prefix: String,
+    width: Option[Int],
+    depth: Option[Int],
+    maskGran: Option[Int] = None,
+    read: Boolean,
+    readEnable: Boolean = false,
+    write: Boolean,
+    writeEnable: Boolean = false
+  ): MacroPort = {
     val realPrefix = if (prefix == "") "" else prefix + "_"
 
     MacroPort(

--- a/macros/src/test/scala/SRAMCompiler.scala
+++ b/macros/src/test/scala/SRAMCompiler.scala
@@ -1,0 +1,15 @@
+package barstools.macros
+
+import mdf.macrolib._
+
+class SRAMCompiler extends MacroCompilerSpec with HasSRAMGenerator {
+  val compiler = generateSRAMCompiler("awesome", "A")
+  val lib = s"lib-SRAMCompiler.json"
+  val verilog = s"v-SRAMCompiler.v"
+  writeToLib(lib, Seq(compiler))
+
+  val mem = s"mem-SRAMCompiler.json"
+  writeToMem(mem, Seq(generateSRAM("mymem", "X", 8, 16)))
+
+  compile(mem, Some(lib), verilog, false, true)
+}

--- a/macros/src/test/scala/SRAMCompiler.scala
+++ b/macros/src/test/scala/SRAMCompiler.scala
@@ -2,14 +2,21 @@ package barstools.macros
 
 import mdf.macrolib._
 
-class SRAMCompiler extends MacroCompilerSpec with HasSRAMGenerator {
+class SRAMCompiler extends MacroCompilerSpec with HasSRAMGenerator with HasSimpleWidthTestGenerator {
   val compiler = generateSRAMCompiler("awesome", "A")
-  val lib = s"lib-SRAMCompiler.json"
   val verilog = s"v-SRAMCompiler.v"
+  override lazy val depth = 16
+  override lazy val memWidth = 8
+  override lazy val libWidth = 8
+  override lazy val mem_name = "mymem"
+  override lazy val memPortPrefix = "X"
+  override lazy val lib_name = "mygroup_8x16_SVT"
+  override lazy val libPortPrefix = "A"
+
   writeToLib(lib, Seq(compiler))
 
-  val mem = s"mem-SRAMCompiler.json"
+
   writeToMem(mem, Seq(generateSRAM("mymem", "X", 8, 16)))
 
-  compile(mem, Some(lib), verilog, false, true)
+  compileExecuteAndTest(mem, Some(lib), verilog, output=output, false, true)
 }

--- a/macros/src/test/scala/SimpleSplitWidth.scala
+++ b/macros/src/test/scala/SimpleSplitWidth.scala
@@ -40,28 +40,28 @@ trait HasSimpleWidthTestGenerator extends HasSimpleTestGenerator {
         } else """UInt<1>("h1")"""
 
 s"""
-    mem_0_${i}.lib_clk <= outer_clk
-    mem_0_${i}.lib_addr <= outer_addr
-    node outer_dout_0_${i} = bits(mem_0_${i}.lib_dout, ${myMemWidth - 1}, 0)
-    mem_0_${i}.lib_din <= bits(outer_din, ${myBaseBit + myMemWidth - 1}, ${myBaseBit})
+    mem_0_${i}.${libPortPrefix}_clk <= ${memPortPrefix}_clk
+    mem_0_${i}.${libPortPrefix}_addr <= ${memPortPrefix}_addr
+    node ${memPortPrefix}_dout_0_${i} = bits(mem_0_${i}.${libPortPrefix}_dout, ${myMemWidth - 1}, 0)
+    mem_0_${i}.${libPortPrefix}_din <= bits(${memPortPrefix}_din, ${myBaseBit + myMemWidth - 1}, ${myBaseBit})
     ${maskStatement}
-    mem_0_${i}.lib_write_en <= and(and(outer_write_en, ${writeEnableBit}), UInt<1>("h1"))
+    mem_0_${i}.${libPortPrefix}_write_en <= and(and(${memPortPrefix}_write_en, ${writeEnableBit}), UInt<1>("h1"))
 """
       }).reduceLeft(_ + _)
 
       // Generate final output that concats together the sub-memories.
       // e.g. cat(outer_dout_0_2, cat(outer_dout_0_1, outer_dout_0_0))
       output append {
-        val doutStatements = ((widthInstances - 1 to 0 by -1) map (i => s"outer_dout_0_${i}"))
+        val doutStatements = ((widthInstances - 1 to 0 by -1) map (i => s"${memPortPrefix}_dout_0_${i}"))
         val catStmt = doutStatements.init.foldRight(doutStatements.last)((l: String, r: String) => s"cat($l, $r)")
 s"""
-    node outer_dout_0 = ${catStmt}
+    node ${memPortPrefix}_dout_0 = ${catStmt}
 """
       }
 
       output append
-"""
-    outer_dout <= mux(UInt<1>("h1"), outer_dout_0, UInt<1>("h0"))
+s"""
+    ${memPortPrefix}_dout <= mux(UInt<1>("h1"), ${memPortPrefix}_dout_0, UInt<1>("h0"))
 """
       output.toString
     }

--- a/macros/src/test/scala/SimpleSplitWidth.scala
+++ b/macros/src/test/scala/SimpleSplitWidth.scala
@@ -398,7 +398,7 @@ class SplitWidth1024x32_readEnable_Lib extends MacroCompilerSpec with HasSRAMGen
       depth=libDepth,
       family="1rw",
       ports=Seq(generateTestPort(
-        "lib", libWidth, libDepth, maskGran=libMaskGran,
+        "lib", Some(libWidth), Some(libDepth), maskGran=libMaskGran,
         write=true, writeEnable=true,
         read=true, readEnable=true
       ))
@@ -456,7 +456,7 @@ class SplitWidth1024x32_readEnable_Mem extends MacroCompilerSpec with HasSRAMGen
       depth=memDepth,
       family="1rw",
       ports=Seq(generateTestPort(
-        "outer", memWidth, memDepth, maskGran=memMaskGran,
+        "outer", Some(memWidth), Some(memDepth), maskGran=memMaskGran,
         write=true, writeEnable=true,
         read=true, readEnable=true
       ))
@@ -482,7 +482,7 @@ class SplitWidth1024x32_readEnable_LibMem extends MacroCompilerSpec with HasSRAM
       depth=libDepth,
       family="1rw",
       ports=Seq(generateTestPort(
-        "lib", libWidth, libDepth, maskGran=libMaskGran,
+        "lib", Some(libWidth), Some(libDepth), maskGran=libMaskGran,
         write=true, writeEnable=true,
         read=true, readEnable=true
       ))
@@ -496,7 +496,7 @@ class SplitWidth1024x32_readEnable_LibMem extends MacroCompilerSpec with HasSRAM
       depth=memDepth,
       family="1rw",
       ports=Seq(generateTestPort(
-        "outer", memWidth, memDepth, maskGran=memMaskGran,
+        "outer", Some(memWidth), Some(memDepth), maskGran=memMaskGran,
         write=true, writeEnable=true,
         read=true, readEnable=true
       ))


### PR DESCRIPTION
Added memory compiler to mdf spec. You add the memory compiler to the lib file, and set the `--use-compiler` flag.