### PR TITLE
Fixed index offset in mask port mapping.

### DIFF
--- a/macros/src/main/scala/MacroCompiler.scala
+++ b/macros/src/main/scala/MacroCompiler.scala
@@ -432,7 +432,7 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
                     // zero out the upper bits.
                     zero
                   } else {
-                    if (i >= memPort.src.width.get) {
+                    if (low + i >= memPort.src.width.get) {
                       // If our bit is larger than the whole width of the mem, just zero out the upper bits.
                       zero
                     } else {

--- a/macros/src/main/scala/MacroCompiler.scala
+++ b/macros/src/main/scala/MacroCompiler.scala
@@ -432,7 +432,7 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
                     // zero out the upper bits.
                     zero
                   } else {
-                    if (low + i >= memPort.src.width.get) {
+                    if ((low + i) >= memPort.src.width.get) {
                       // If our bit is larger than the whole width of the mem, just zero out the upper bits.
                       zero
                     } else {


### PR DESCRIPTION
Fixing index offset in mask port mapping. This was originally done in #34 but did not make it to master.

Failure looked like
```
Exception in thread "main" firrtl.passes.PassExceptions:
firrtl.passes.CheckWidths$BitsWidthException: : [module tag_array_ext] High bit 9 in bits operator is larger than input width 8 in bits(R│[dunn@bwrcrdsl-1] /tools/B/dunn/hammer-workspace/project-template
W0_mask, 9, 9).
```