### PR TITLE
stop exceptions on empty conf files

### DIFF
--- a/macros/src/main/scala/MacroCompiler.scala
+++ b/macros/src/main/scala/MacroCompiler.scala
@@ -839,8 +839,7 @@ object MacroCompiler extends App {
           }
           case None =>
         }
-      }
-      else {
+      } else {
         // Warn user
         System.err println "WARNING: Empty *.mems.conf file. No memories generated."
 

--- a/macros/src/main/scala/MacroCompiler.scala
+++ b/macros/src/main/scala/MacroCompiler.scala
@@ -840,6 +840,20 @@ object MacroCompiler extends App {
           case None =>
         }
       }
+      else {
+        // Warn user
+        System.err println "WARNING: Empty *.mems.conf file. No memories generated."
+
+        // Emit empty verilog file if no macros found
+        params.get(Verilog) match {
+          case Some(verilogFile: String) => {
+            // Create an empty verilog file
+            val verilogWriter = new FileWriter(new File(verilogFile))
+            verilogWriter.close()
+          }
+          case None =>
+        }
+      }
     } catch {
       case e: java.util.NoSuchElementException =>
         e.printStackTrace()

--- a/macros/src/main/scala/MemConf.scala
+++ b/macros/src/main/scala/MemConf.scala
@@ -49,8 +49,7 @@ object MemConf {
   def fromString(s: String): Seq[MemConf] = {
     if (s.isEmpty) {
       Seq[MemConf]()
-    }
-    else {
+    } else {
       s.split("\n").toSeq.map(_ match {
         case MemConf.regex(name, depth, width, ports, maskGran) => MemConf(name, depth.toInt, width.toInt, MemPort.fromString(ports), Option(maskGran).map(_.toInt))
         case _ => throw new Exception(s"Error parsing MemConf string : ${s}")

--- a/macros/src/main/scala/MemConf.scala
+++ b/macros/src/main/scala/MemConf.scala
@@ -47,9 +47,14 @@ object MemConf {
   val regex = raw"\s*name\s+(\w+)\s+depth\s+(\d+)\s+width\s+(\d+)\s+ports\s+([^\s]+)\s+(?:mask_gran\s+(\d+))?\s*".r
 
   def fromString(s: String): Seq[MemConf] = {
-    s.split("\n").toSeq.map(_ match {
-      case MemConf.regex(name, depth, width, ports, maskGran) => MemConf(name, depth.toInt, width.toInt, MemPort.fromString(ports), Option(maskGran).map(_.toInt))
-      case _ => throw new Exception(s"Error parsing MemConf string : ${s}")
-    })
+    if (s.isEmpty) {
+      Seq[MemConf]()
+    }
+    else {
+      s.split("\n").toSeq.map(_ match {
+        case MemConf.regex(name, depth, width, ports, maskGran) => MemConf(name, depth.toInt, width.toInt, MemPort.fromString(ports), Option(maskGran).map(_.toInt))
+        case _ => throw new Exception(s"Error parsing MemConf string : ${s}")
+      })
+    }
   }
 }


### PR DESCRIPTION
When running unit tests for `testchipip`, it errors since there are no memories generated in the `*.mems.conf`. Thus this PR is to address this by not excepting out.