### PR TITLE
SRAM mapping improvements

### DIFF
--- a/macros/src/main/scala/CostMetric.scala
+++ b/macros/src/main/scala/CostMetric.scala
@@ -122,7 +122,16 @@ object DefaultMetric extends CostMetric with CostMetricCompanion {
     }
     val depthCost = (mem.src.depth.toDouble / lib.src.depth.toDouble)
     val widthCost = (memWidth.toDouble / lib.src.width.toDouble)
-    return Some(depthCost * widthCost)
+    val bitsCost = (lib.src.depth * lib.src.width)
+    // The most complicated case occurs when you have a 1x1 lib and a 1Mx1M lib and a third sane lib.
+    // In this case you want to ensure that a lib slightly smaller or larger than mem as the third lib
+    // will always be selected over the stupid libs.
+    if(widthCost < 1 && depthCost < 1) Some(bitsCost) // If the lib is bigger than pick the smallest lib
+    // If its not bigger in both dimensions pick the smallest in the dimension that the lib is larger in
+    else if(widthCost < 1) Some(depthCost * lib.src.width)
+    else if(depthCost < 1) Some(widthCost * lib.src.depth)
+    // If the lib is equal or smaller than source mem pick the largest lib
+    else Some(depthCost * widthCost)
   }
 
   override def commandLineParams = Map()

--- a/macros/src/main/scala/MacroCompiler.scala
+++ b/macros/src/main/scala/MacroCompiler.scala
@@ -565,7 +565,7 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
 
         // Try to compile mem against each lib in libs, keeping track of the
         // best compiled version, external lib used, and cost.
-        val (best, cost) = (libs foldLeft (None: Option[(Module, ExtModule)], BigInt(Long.MaxValue))){
+        val (best, cost) = (fullLibs foldLeft (None: Option[(Module, ExtModule)], Double.MaxValue)){
           case ((best, cost), lib) if mem.src.ports.size != lib.src.ports.size =>
             /* Palmer: FIXME: This just assumes the Chisel and vendor ports are in the same
              * order, but I'm starting with what actually gets generated. */

--- a/macros/src/main/scala/MacroCompiler.scala
+++ b/macros/src/main/scala/MacroCompiler.scala
@@ -393,12 +393,14 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
               /* Palmer: The input port to a memory just needs to happen in parallel,
                * this does a part select to narrow the memory down. */
               stmts += connectPorts(bits(WRef(mem), high, low), lib, lib_polarity)
-            case (None, Some(lib)) =>
+              case (None, Some(lib)) =>
               /* Palmer: If the inner memory has an input port but the other
                * one doesn't then it's safe to just leave the inner
                * port floating.  This should be handled by the
                * default value of the write enable, so nothing should
                * every make it into the memory. */
+              //Firrtl cares about dangling inputs now tie it off
+              stmts += IsInvalid(NoInfo, WSubField(inst, lib.name))
             case (None, None) =>
               /* Palmer: If there's no input ports at all (ie, read-only
                * port on the memory) then just don't worry about it,

--- a/macros/src/main/scala/MacroCompiler.scala
+++ b/macros/src/main/scala/MacroCompiler.scala
@@ -569,7 +569,6 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
           val memMask = mem.ports map (_.maskGran) find (_.isDefined) map (_.get)
           val libMask = group.ports map (_.maskGran) find (_.isDefined) map (_.get)
           (memMask, libMask) match {
-            case (_, Some(1)) => true
             case (None, _) => true
             case (Some(_), None) => false
             case (Some(m), Some(l)) => l <= m //Ignore memories that don't have nice mask

--- a/macros/src/main/scala/MacroCompiler.scala
+++ b/macros/src/main/scala/MacroCompiler.scala
@@ -302,7 +302,7 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
             case (None, None) => one
           }
           selectRegs(ref.name) = WRef(regName, tpe)
-          stmts += DefRegister(NoInfo, regName, tpe, WRef(port.clock.name), zero, WRef(regName))
+          stmts += DefRegister(NoInfo, regName, tpe, WRef(port.clock.get.name), zero, WRef(regName))
           stmts += Connect(NoInfo, WRef(regName), Mux(enable, WRef(nodeName), WRef(regName), tpe))
         }
       }
@@ -348,9 +348,11 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
 
           // Clock port mapping
           /* Palmer: FIXME: I don't handle memories with read/write clocks yet. */
-          stmts += connectPorts(WRef(memPort.src.clock.name),
-                                libPort.src.clock.name,
-                                libPort.src.clock.polarity)
+          /* Colin not all libPorts have clocks but all memPorts do*/
+          libPort.src.clock.foreach { cPort =>
+            stmts += connectPorts(WRef(memPort.src.clock.get.name),
+                                       cPort.name,
+                                       cPort.polarity) }
 
           // Adress port mapping
           /* Palmer: The address port to a memory is just the low-order bits of

--- a/macros/src/main/scala/SynFlops.scala
+++ b/macros/src/main/scala/SynFlops.scala
@@ -38,7 +38,7 @@ class SynFlopsPass(synflops: Boolean, libs: Seq[Macro]) extends firrtl.passes.Pa
     )
 
     val readConnects = lib.readers.zipWithIndex flatMap { case (r, i) =>
-      val clock = portToExpression(r.src.clock)
+      val clock = portToExpression(r.src.clock.get)
       val address = portToExpression(r.src.address)
       val enable = (r.src chipEnable, r.src readEnable) match {
         case (Some(en_port), Some(re_port)) =>
@@ -63,7 +63,7 @@ class SynFlopsPass(synflops: Boolean, libs: Seq[Macro]) extends firrtl.passes.Pa
     }
 
     val writeConnects = lib.writers.zipWithIndex flatMap { case (w, i) =>
-      val clock = portToExpression(w.src.clock)
+      val clock = portToExpression(w.src.clock.get)
       val address = portToExpression(w.src.address)
       val enable = (w.src.chipEnable, w.src.writeEnable) match {
         case (Some(en), Some(we)) =>
@@ -95,7 +95,7 @@ class SynFlopsPass(synflops: Boolean, libs: Seq[Macro]) extends firrtl.passes.Pa
     }
 
     val readwriteConnects = lib.readwriters.zipWithIndex flatMap { case (rw, i) =>
-      val clock = portToExpression(rw.src.clock)
+      val clock = portToExpression(rw.src.clock.get)
       val address = portToExpression(rw.src.address)
       val wmode = rw.src.writeEnable match {
         case Some(we) => portToExpression(we)

--- a/macros/src/main/scala/Utils.scala
+++ b/macros/src/main/scala/Utils.scala
@@ -24,8 +24,8 @@ class FirrtlMacroPort(port: MacroPort) {
 
   // Bundle representing this macro port.
   val tpe = BundleType(Seq(
-    Field(port.clock.name, Flip, ClockType),
     Field(port.address.name, Flip, addrType)) ++
+    (port.clock map (p => Field(p.name, Flip, ClockType))) ++
     (port.input map (p => Field(p.name, Flip, dataType))) ++
     (port.output map (p => Field(p.name, Default, dataType))) ++
     (port.chipEnable map (p => Field(p.name, Flip, BoolType))) ++
@@ -93,7 +93,7 @@ object Utils {
         MacroPort(
           width=Some(width), depth=Some(depth),
           address=PolarizedPort(s"${portName}_addr", ActiveHigh),
-          clock=PolarizedPort(s"${portName}_clk", PositiveEdge),
+          clock=Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
           chipEnable=Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
           output=Some(PolarizedPort(s"${portName}_data", ActiveHigh))
         ) }
@@ -103,7 +103,7 @@ object Utils {
         MacroPort(
           width=Some(width), depth=Some(depth),
           address=PolarizedPort(s"${portName}_addr", ActiveHigh),
-          clock=PolarizedPort(s"${portName}_clk", PositiveEdge),
+          clock=Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
           writeEnable=Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
           input=Some(PolarizedPort(s"${portName}_data", ActiveHigh))
         ) }
@@ -113,7 +113,7 @@ object Utils {
         MacroPort(
           width=Some(width), depth=Some(depth),
           address=PolarizedPort(s"${portName}_addr", ActiveHigh),
-          clock=PolarizedPort(s"${portName}_clk", PositiveEdge),
+          clock=Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
           writeEnable=Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
           maskPort=Some(PolarizedPort(s"${portName}_mask", ActiveHigh)),
           maskGran=maskGran,
@@ -125,7 +125,7 @@ object Utils {
         MacroPort(
           width=Some(width), depth=Some(depth),
           address=PolarizedPort(s"${portName}_addr", ActiveHigh),
-          clock=PolarizedPort(s"${portName}_clk", PositiveEdge),
+          clock=Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
           chipEnable=Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
           writeEnable=Some(PolarizedPort(s"${portName}_wmode", ActiveHigh)),
           input=Some(PolarizedPort(s"${portName}_wdata", ActiveHigh)),
@@ -137,7 +137,7 @@ object Utils {
         MacroPort(
           width=Some(width), depth=Some(depth),
           address=PolarizedPort(s"${portName}_addr", ActiveHigh),
-          clock=PolarizedPort(s"${portName}_clk", PositiveEdge),
+          clock=Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
           chipEnable=Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
           writeEnable=Some(PolarizedPort(s"${portName}_wmode", ActiveHigh)),
           maskPort=Some(PolarizedPort(s"${portName}_wmask", ActiveHigh)),

--- a/macros/src/test/scala/CostFunction.scala
+++ b/macros/src/test/scala/CostFunction.scala
@@ -10,7 +10,7 @@ import mdf.macrolib._
  */
 object TestMinWidthMetric extends CostMetric with CostMetricCompanion {
   // Smaller width = lower cost = favoured
-  override def cost(mem: Macro, lib: Macro): Option[BigInt] = Some(lib.src.width)
+  override def cost(mem: Macro, lib: Macro): Option[Double] = Some(lib.src.width)
 
   override def commandLineParams = Map()
   override def name = "TestMinWidthMetric"
@@ -68,8 +68,8 @@ class SelectCostMetric extends MacroCompilerSpec with HasSRAMGenerator {
 """
 circuit target_memory :
   module target_memory :
-    input clk : Clock
     input addr : UInt<10>
+    input clk : Clock
     input din : UInt<128>
     output dout : UInt<128>
     input write_en : UInt<1>
@@ -102,8 +102,8 @@ circuit target_memory :
     dout <= mux(UInt<1>("h1"), dout_0, UInt<1>("h0"))
 
   extmodule SRAM_WIDTH_32 :
-    input clk : Clock
     input addr : UInt<10>
+    input clk : Clock
     input din : UInt<32>
     output dout : UInt<32>
     input write_en : UInt<1>

--- a/macros/src/test/scala/MacroCompilerSpec.scala
+++ b/macros/src/test/scala/MacroCompilerSpec.scala
@@ -99,7 +99,7 @@ abstract class MacroCompilerSpec extends org.scalatest.FlatSpec with org.scalate
     val macros = mems map (_.blackbox)
     val circuit = Circuit(NoInfo, macros, macros.last.name)
     val passes = Seq(
-      new MacroCompilerPass(Some(mems), libs, getCostMetric, if (synflops) MacroCompilerAnnotation.Synflops else MacroCompilerAnnotation.Default),
+      new MacroCompilerPass(Some(mems), libs, None, getCostMetric, if (synflops) MacroCompilerAnnotation.Synflops else MacroCompilerAnnotation.Default),
       new SynFlopsPass(synflops, libs getOrElse mems),
       RemoveEmpty)
     val result: Circuit = (passes foldLeft circuit)((c, pass) => pass run c)
@@ -140,7 +140,7 @@ trait HasSRAMGenerator {
 
     MacroPort(
       address = PolarizedPort(name = realPrefix + "addr", polarity = ActiveHigh),
-      clock = PolarizedPort(name = realPrefix + "clk", polarity = PositiveEdge),
+      clock = Some(PolarizedPort(name = realPrefix + "clk", polarity = PositiveEdge)),
 
       readEnable = if (readEnable) Some(PolarizedPort(name = realPrefix + "read_en", polarity = ActiveHigh)) else None,
       writeEnable = if (writeEnable) Some(PolarizedPort(name = realPrefix + "write_en", polarity = ActiveHigh)) else None,
@@ -350,8 +350,8 @@ trait HasSimpleTestGenerator {
       }
       val extraPortsStr = extraPorts.map { case (name, bits) => s"    input $name : UInt<$bits>" }.mkString("\n")
       s"""
-    input ${realPrefix}clk : Clock
     input ${realPrefix}addr : UInt<$addrWidth>
+    input ${realPrefix}clk : Clock
     $writeStr
     $readStr
     $readEnableStr

--- a/macros/src/test/scala/SimpleSplitDepth.scala
+++ b/macros/src/test/scala/SimpleSplitDepth.scala
@@ -255,8 +255,8 @@ class SplitDepth2048x8_extraPort extends MacroCompilerSpec with HasSRAMGenerator
 """
 circuit target_memory :
   module target_memory :
-    input outer_clk : Clock
     input outer_addr : UInt<11>
+    input outer_clk : Clock
     input outer_din : UInt<8>
     output outer_dout : UInt<8>
     input outer_write_en : UInt<1>
@@ -287,8 +287,8 @@ circuit target_memory :
     node outer_dout_1 = outer_dout_1_0
     outer_dout <= mux(eq(outer_addr_sel_reg, UInt<1>("h0")), outer_dout_0, mux(eq(outer_addr_sel_reg, UInt<1>("h1")), outer_dout_1, UInt<1>("h0")))
   extmodule awesome_lib_mem :
-    input lib_clk : Clock
     input lib_addr : UInt<10>
+    input lib_clk : Clock
     input lib_din : UInt<8>
     output lib_dout : UInt<8>
     input lib_write_en : UInt<1>
@@ -345,11 +345,11 @@ class SplitDepth_SplitPortsNonMasked extends MacroCompilerSpec with HasSRAMGener
 """
 circuit target_memory :
   module target_memory :
-    input outerB_clk : Clock
     input outerB_addr : UInt<11>
+    input outerB_clk : Clock
     output outerB_dout : UInt<8>
-    input outerA_clk : Clock
     input outerA_addr : UInt<11>
+    input outerA_clk : Clock
     input outerA_din : UInt<8>
     input outerA_write_en : UInt<1>
 
@@ -379,11 +379,11 @@ circuit target_memory :
     outerB_dout <= mux(eq(outerB_addr_sel_reg, UInt<1>("h0")), outerB_dout_0, mux(eq(outerB_addr_sel_reg, UInt<1>("h1")), outerB_dout_1, UInt<1>("h0")))
 
   extmodule awesome_lib_mem :
-    input innerA_clk : Clock
     input innerA_addr : UInt<10>
+    input innerA_clk : Clock
     output innerA_dout : UInt<8>
-    input innerB_clk : Clock
     input innerB_addr : UInt<10>
+    input innerB_clk : Clock
     input innerB_din : UInt<8>
     input innerB_write_en : UInt<1>
 
@@ -506,11 +506,11 @@ class SplitDepth_SplitPortsMasked extends MacroCompilerSpec with HasSRAMGenerato
 """
 circuit target_memory :
   module target_memory :
-    input outerB_clk : Clock
     input outerB_addr : UInt<11>
+    input outerB_clk : Clock
     output outerB_dout : UInt<8>
-    input outerA_clk : Clock
     input outerA_addr : UInt<11>
+    input outerA_clk : Clock
     input outerA_din : UInt<8>
     input outerA_write_en : UInt<1>
     input outerA_mask : UInt<1>
@@ -543,11 +543,11 @@ circuit target_memory :
     outerB_dout <= mux(eq(outerB_addr_sel_reg, UInt<1>("h0")), outerB_dout_0, mux(eq(outerB_addr_sel_reg, UInt<1>("h1")), outerB_dout_1, UInt<1>("h0")))
 
   extmodule awesome_lib_mem :
-    input innerA_clk : Clock
     input innerA_addr : UInt<10>
+    input innerA_clk : Clock
     output innerA_dout : UInt<8>
-    input innerB_clk : Clock
     input innerB_addr : UInt<10>
+    input innerB_clk : Clock
     input innerB_din : UInt<8>
     input innerB_write_en : UInt<1>
     input innerB_mask : UInt<8>

--- a/macros/src/test/scala/SpecificExamples.scala
+++ b/macros/src/test/scala/SpecificExamples.scala
@@ -203,12 +203,12 @@ class BOOMTest extends MacroCompilerSpec with HasSRAMGenerator {
 """
 circuit smem_0_ext :
   module _T_182_ext :
-    input R0_clk : Clock
     input R0_addr : UInt<6>
+    input R0_clk : Clock
     output R0_data : UInt<88>
     input R0_en : UInt<1>
-    input W0_clk : Clock
     input W0_addr : UInt<6>
+    input W0_clk : Clock
     input W0_data : UInt<88>
     input W0_en : UInt<1>
     input W0_mask : UInt<4>
@@ -249,24 +249,28 @@ circuit smem_0_ext :
     mem_0_0.CE2 <= R0_clk
     mem_0_0.A2 <= R0_addr
     node R0_data_0_0 = bits(mem_0_0.O2, 21, 0)
+    mem_0_0.I2 is invalid
     mem_0_0.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<1>("h0"))))
     mem_0_0.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<1>("h0"))))
     mem_0_0.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<1>("h0"))))
     mem_0_1.CE2 <= R0_clk
     mem_0_1.A2 <= R0_addr
     node R0_data_0_1 = bits(mem_0_1.O2, 21, 0)
+    mem_0_1.I2 is invalid
     mem_0_1.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<1>("h0"))))
     mem_0_1.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<1>("h0"))))
     mem_0_1.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<1>("h0"))))
     mem_0_2.CE2 <= R0_clk
     mem_0_2.A2 <= R0_addr
     node R0_data_0_2 = bits(mem_0_2.O2, 21, 0)
+    mem_0_2.I2 is invalid
     mem_0_2.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<1>("h0"))))
     mem_0_2.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<1>("h0"))))
     mem_0_2.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<1>("h0"))))
     mem_0_3.CE2 <= R0_clk
     mem_0_3.A2 <= R0_addr
     node R0_data_0_3 = bits(mem_0_3.O2, 21, 0)
+    mem_0_3.I2 is invalid
     mem_0_3.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<1>("h0"))))
     mem_0_3.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<1>("h0"))))
     mem_0_3.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<1>("h0"))))
@@ -302,56 +306,42 @@ circuit smem_0_ext :
     mem_1_0.CE2 <= R0_clk
     mem_1_0.A2 <= R0_addr
     node R0_data_1_0 = bits(mem_1_0.O2, 21, 0)
+    mem_1_0.I2 is invalid
     mem_1_0.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<1>("h1"))))
     mem_1_0.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<1>("h1"))))
     mem_1_0.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<1>("h1"))))
     mem_1_1.CE2 <= R0_clk
     mem_1_1.A2 <= R0_addr
     node R0_data_1_1 = bits(mem_1_1.O2, 21, 0)
+    mem_1_1.I2 is invalid
     mem_1_1.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<1>("h1"))))
     mem_1_1.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<1>("h1"))))
     mem_1_1.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<1>("h1"))))
     mem_1_2.CE2 <= R0_clk
     mem_1_2.A2 <= R0_addr
     node R0_data_1_2 = bits(mem_1_2.O2, 21, 0)
+    mem_1_2.I2 is invalid
     mem_1_2.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<1>("h1"))))
     mem_1_2.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<1>("h1"))))
     mem_1_2.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<1>("h1"))))
     mem_1_3.CE2 <= R0_clk
     mem_1_3.A2 <= R0_addr
     node R0_data_1_3 = bits(mem_1_3.O2, 21, 0)
+    mem_1_3.I2 is invalid
     mem_1_3.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<1>("h1"))))
     mem_1_3.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<1>("h1"))))
     mem_1_3.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<1>("h1"))))
     node R0_data_1 = cat(R0_data_1_3, cat(R0_data_1_2, cat(R0_data_1_1, R0_data_1_0)))
     R0_data <= mux(eq(R0_addr_sel_reg, UInt<1>("h0")), R0_data_0, mux(eq(R0_addr_sel_reg, UInt<1>("h1")), R0_data_1, UInt<1>("h0")))
 
-  extmodule my_sram_2rw_32x22 :
-    input CE1 : Clock
-    input A1 : UInt<5>
-    input I1 : UInt<22>
-    output O1 : UInt<22>
-    input CSB1 : UInt<1>
-    input OEB1 : UInt<1>
-    input WEB1 : UInt<1>
-    input CE2 : Clock
-    input A2 : UInt<5>
-    input I2 : UInt<22>
-    output O2 : UInt<22>
-    input CSB2 : UInt<1>
-    input OEB2 : UInt<1>
-    input WEB2 : UInt<1>
-
-    defname = my_sram_2rw_32x22
-
 
   module _T_84_ext :
-    input R0_clk : Clock
     input R0_addr : UInt<9>
+    input R0_clk : Clock
     output R0_data : UInt<64>
     input R0_en : UInt<1>
-    input W0_clk : Clock
     input W0_addr : UInt<9>
+    input W0_clk : Clock
     input W0_data : UInt<64>
     input W0_en : UInt<1>
     input W0_mask : UInt<1>
@@ -378,12 +368,14 @@ circuit smem_0_ext :
     mem_0_0.CE2 <= R0_clk
     mem_0_0.A2 <= R0_addr
     node R0_data_0_0 = bits(mem_0_0.O2, 31, 0)
+    mem_0_0.I2 is invalid
     mem_0_0.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<2>("h0"))))
     mem_0_0.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<2>("h0"))))
     mem_0_0.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<2>("h0"))))
     mem_0_1.CE2 <= R0_clk
     mem_0_1.A2 <= R0_addr
     node R0_data_0_1 = bits(mem_0_1.O2, 31, 0)
+    mem_0_1.I2 is invalid
     mem_0_1.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<2>("h0"))))
     mem_0_1.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<2>("h0"))))
     mem_0_1.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<2>("h0"))))
@@ -405,12 +397,14 @@ circuit smem_0_ext :
     mem_1_0.CE2 <= R0_clk
     mem_1_0.A2 <= R0_addr
     node R0_data_1_0 = bits(mem_1_0.O2, 31, 0)
+    mem_1_0.I2 is invalid
     mem_1_0.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<2>("h1"))))
     mem_1_0.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<2>("h1"))))
     mem_1_0.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<2>("h1"))))
     mem_1_1.CE2 <= R0_clk
     mem_1_1.A2 <= R0_addr
     node R0_data_1_1 = bits(mem_1_1.O2, 31, 0)
+    mem_1_1.I2 is invalid
     mem_1_1.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<2>("h1"))))
     mem_1_1.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<2>("h1"))))
     mem_1_1.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<2>("h1"))))
@@ -432,12 +426,14 @@ circuit smem_0_ext :
     mem_2_0.CE2 <= R0_clk
     mem_2_0.A2 <= R0_addr
     node R0_data_2_0 = bits(mem_2_0.O2, 31, 0)
+    mem_2_0.I2 is invalid
     mem_2_0.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<2>("h2"))))
     mem_2_0.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<2>("h2"))))
     mem_2_0.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<2>("h2"))))
     mem_2_1.CE2 <= R0_clk
     mem_2_1.A2 <= R0_addr
     node R0_data_2_1 = bits(mem_2_1.O2, 31, 0)
+    mem_2_1.I2 is invalid
     mem_2_1.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<2>("h2"))))
     mem_2_1.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<2>("h2"))))
     mem_2_1.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<2>("h2"))))
@@ -459,12 +455,14 @@ circuit smem_0_ext :
     mem_3_0.CE2 <= R0_clk
     mem_3_0.A2 <= R0_addr
     node R0_data_3_0 = bits(mem_3_0.O2, 31, 0)
+    mem_3_0.I2 is invalid
     mem_3_0.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<2>("h3"))))
     mem_3_0.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<2>("h3"))))
     mem_3_0.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<2>("h3"))))
     mem_3_1.CE2 <= R0_clk
     mem_3_1.A2 <= R0_addr
     node R0_data_3_1 = bits(mem_3_1.O2, 31, 0)
+    mem_3_1.I2 is invalid
     mem_3_1.OEB2 <= not(and(not(UInt<1>("h0")), eq(R0_addr_sel, UInt<2>("h3"))))
     mem_3_1.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), eq(R0_addr_sel, UInt<2>("h3"))))
     mem_3_1.CSB2 <= not(and(R0_en, eq(R0_addr_sel, UInt<2>("h3"))))
@@ -472,15 +470,15 @@ circuit smem_0_ext :
     R0_data <= mux(eq(R0_addr_sel_reg, UInt<2>("h0")), R0_data_0, mux(eq(R0_addr_sel_reg, UInt<2>("h1")), R0_data_1, mux(eq(R0_addr_sel_reg, UInt<2>("h2")), R0_data_2, mux(eq(R0_addr_sel_reg, UInt<2>("h3")), R0_data_3, UInt<1>("h0")))))
 
   extmodule my_sram_2rw_128x32 :
-    input CE1 : Clock
     input A1 : UInt<7>
+    input CE1 : Clock
     input I1 : UInt<32>
     output O1 : UInt<32>
     input CSB1 : UInt<1>
     input OEB1 : UInt<1>
     input WEB1 : UInt<1>
-    input CE2 : Clock
     input A2 : UInt<7>
+    input CE2 : Clock
     input I2 : UInt<32>
     output O2 : UInt<32>
     input CSB2 : UInt<1>
@@ -491,8 +489,8 @@ circuit smem_0_ext :
 
 
   module tag_array_ext :
-    input RW0_clk : Clock
     input RW0_addr : UInt<6>
+    input RW0_clk : Clock
     input RW0_wdata : UInt<80>
     output RW0_rdata : UInt<80>
     input RW0_en : UInt<1>
@@ -535,8 +533,8 @@ circuit smem_0_ext :
     RW0_rdata <= mux(UInt<1>("h1"), RW0_rdata_0, UInt<1>("h0"))
 
   extmodule my_sram_1rw_64x32 :
-    input CE : Clock
     input A : UInt<6>
+    input CE : Clock
     input I : UInt<32>
     output O : UInt<32>
     input CSB : UInt<1>
@@ -547,8 +545,8 @@ circuit smem_0_ext :
 
 
   module _T_886_ext :
-    input RW0_clk : Clock
     input RW0_addr : UInt<9>
+    input RW0_clk : Clock
     input RW0_wdata : UInt<64>
     output RW0_rdata : UInt<64>
     input RW0_en : UInt<1>
@@ -574,8 +572,8 @@ circuit smem_0_ext :
     RW0_rdata <= mux(UInt<1>("h1"), RW0_rdata_0, UInt<1>("h0"))
 
   extmodule my_sram_1rw_512x32 :
-    input CE : Clock
     input A : UInt<9>
+    input CE : Clock
     input I : UInt<32>
     output O : UInt<32>
     input CSB : UInt<1>
@@ -586,105 +584,68 @@ circuit smem_0_ext :
 
 
   module entries_info_ext :
-    input R0_clk : Clock
     input R0_addr : UInt<5>
+    input R0_clk : Clock
     output R0_data : UInt<40>
     input R0_en : UInt<1>
-    input W0_clk : Clock
     input W0_addr : UInt<5>
+    input W0_clk : Clock
     input W0_data : UInt<40>
     input W0_en : UInt<1>
 
-    inst mem_0_0 of my_sram_2rw_32x8
-    inst mem_0_1 of my_sram_2rw_32x8
-    inst mem_0_2 of my_sram_2rw_32x8
-    inst mem_0_3 of my_sram_2rw_32x8
-    inst mem_0_4 of my_sram_2rw_32x8
+    inst mem_0_0 of my_sram_2rw_32x22
+    inst mem_0_1 of my_sram_2rw_32x22
     mem_0_0.CE1 <= W0_clk
     mem_0_0.A1 <= W0_addr
-    mem_0_0.I1 <= bits(W0_data, 7, 0)
+    mem_0_0.I1 <= bits(W0_data, 21, 0)
     mem_0_0.OEB1 <= not(and(not(UInt<1>("h1")), UInt<1>("h1")))
     mem_0_0.WEB1 <= not(and(and(UInt<1>("h1"), UInt<1>("h1")), UInt<1>("h1")))
     mem_0_0.CSB1 <= not(and(W0_en, UInt<1>("h1")))
     mem_0_1.CE1 <= W0_clk
     mem_0_1.A1 <= W0_addr
-    mem_0_1.I1 <= bits(W0_data, 15, 8)
+    mem_0_1.I1 <= bits(W0_data, 39, 22)
     mem_0_1.OEB1 <= not(and(not(UInt<1>("h1")), UInt<1>("h1")))
     mem_0_1.WEB1 <= not(and(and(UInt<1>("h1"), UInt<1>("h1")), UInt<1>("h1")))
     mem_0_1.CSB1 <= not(and(W0_en, UInt<1>("h1")))
-    mem_0_2.CE1 <= W0_clk
-    mem_0_2.A1 <= W0_addr
-    mem_0_2.I1 <= bits(W0_data, 23, 16)
-    mem_0_2.OEB1 <= not(and(not(UInt<1>("h1")), UInt<1>("h1")))
-    mem_0_2.WEB1 <= not(and(and(UInt<1>("h1"), UInt<1>("h1")), UInt<1>("h1")))
-    mem_0_2.CSB1 <= not(and(W0_en, UInt<1>("h1")))
-    mem_0_3.CE1 <= W0_clk
-    mem_0_3.A1 <= W0_addr
-    mem_0_3.I1 <= bits(W0_data, 31, 24)
-    mem_0_3.OEB1 <= not(and(not(UInt<1>("h1")), UInt<1>("h1")))
-    mem_0_3.WEB1 <= not(and(and(UInt<1>("h1"), UInt<1>("h1")), UInt<1>("h1")))
-    mem_0_3.CSB1 <= not(and(W0_en, UInt<1>("h1")))
-    mem_0_4.CE1 <= W0_clk
-    mem_0_4.A1 <= W0_addr
-    mem_0_4.I1 <= bits(W0_data, 39, 32)
-    mem_0_4.OEB1 <= not(and(not(UInt<1>("h1")), UInt<1>("h1")))
-    mem_0_4.WEB1 <= not(and(and(UInt<1>("h1"), UInt<1>("h1")), UInt<1>("h1")))
-    mem_0_4.CSB1 <= not(and(W0_en, UInt<1>("h1")))
     mem_0_0.CE2 <= R0_clk
     mem_0_0.A2 <= R0_addr
-    node R0_data_0_0 = bits(mem_0_0.O2, 7, 0)
+    node R0_data_0_0 = bits(mem_0_0.O2, 21, 0)
+    mem_0_0.I2 is invalid
     mem_0_0.OEB2 <= not(and(not(UInt<1>("h0")), UInt<1>("h1")))
     mem_0_0.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), UInt<1>("h1")))
     mem_0_0.CSB2 <= not(and(R0_en, UInt<1>("h1")))
     mem_0_1.CE2 <= R0_clk
     mem_0_1.A2 <= R0_addr
-    node R0_data_0_1 = bits(mem_0_1.O2, 7, 0)
+    node R0_data_0_1 = bits(mem_0_1.O2, 17, 0)
+    mem_0_1.I2 is invalid
     mem_0_1.OEB2 <= not(and(not(UInt<1>("h0")), UInt<1>("h1")))
     mem_0_1.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), UInt<1>("h1")))
     mem_0_1.CSB2 <= not(and(R0_en, UInt<1>("h1")))
-    mem_0_2.CE2 <= R0_clk
-    mem_0_2.A2 <= R0_addr
-    node R0_data_0_2 = bits(mem_0_2.O2, 7, 0)
-    mem_0_2.OEB2 <= not(and(not(UInt<1>("h0")), UInt<1>("h1")))
-    mem_0_2.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), UInt<1>("h1")))
-    mem_0_2.CSB2 <= not(and(R0_en, UInt<1>("h1")))
-    mem_0_3.CE2 <= R0_clk
-    mem_0_3.A2 <= R0_addr
-    node R0_data_0_3 = bits(mem_0_3.O2, 7, 0)
-    mem_0_3.OEB2 <= not(and(not(UInt<1>("h0")), UInt<1>("h1")))
-    mem_0_3.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), UInt<1>("h1")))
-    mem_0_3.CSB2 <= not(and(R0_en, UInt<1>("h1")))
-    mem_0_4.CE2 <= R0_clk
-    mem_0_4.A2 <= R0_addr
-    node R0_data_0_4 = bits(mem_0_4.O2, 7, 0)
-    mem_0_4.OEB2 <= not(and(not(UInt<1>("h0")), UInt<1>("h1")))
-    mem_0_4.WEB2 <= not(and(and(UInt<1>("h0"), UInt<1>("h1")), UInt<1>("h1")))
-    mem_0_4.CSB2 <= not(and(R0_en, UInt<1>("h1")))
-    node R0_data_0 = cat(R0_data_0_4, cat(R0_data_0_3, cat(R0_data_0_2, cat(R0_data_0_1, R0_data_0_0))))
+    node R0_data_0 = cat(R0_data_0_1, R0_data_0_0)
     R0_data <= mux(UInt<1>("h1"), R0_data_0, UInt<1>("h0"))
 
-  extmodule my_sram_2rw_32x8 :
-    input CE1 : Clock
+  extmodule my_sram_2rw_32x22 :
     input A1 : UInt<5>
-    input I1 : UInt<8>
-    output O1 : UInt<8>
+    input CE1 : Clock
+    input I1 : UInt<22>
+    output O1 : UInt<22>
     input CSB1 : UInt<1>
     input OEB1 : UInt<1>
     input WEB1 : UInt<1>
-    input CE2 : Clock
     input A2 : UInt<5>
-    input I2 : UInt<8>
-    output O2 : UInt<8>
+    input CE2 : Clock
+    input I2 : UInt<22>
+    output O2 : UInt<22>
     input CSB2 : UInt<1>
     input OEB2 : UInt<1>
     input WEB2 : UInt<1>
 
-    defname = my_sram_2rw_32x8
+    defname = my_sram_2rw_32x22
 
 
   module smem_ext :
-    input RW0_clk : Clock
     input RW0_addr : UInt<5>
+    input RW0_clk : Clock
     input RW0_wdata : UInt<32>
     output RW0_rdata : UInt<32>
     input RW0_en : UInt<1>
@@ -951,8 +912,8 @@ circuit smem_0_ext :
     RW0_rdata <= mux(UInt<1>("h1"), RW0_rdata_0, UInt<1>("h0"))
 
   module smem_0_ext :
-    input RW0_clk : Clock
     input RW0_addr : UInt<6>
+    input RW0_clk : Clock
     input RW0_wdata : UInt<32>
     output RW0_rdata : UInt<32>
     input RW0_en : UInt<1>
@@ -1219,8 +1180,8 @@ circuit smem_0_ext :
     RW0_rdata <= mux(UInt<1>("h1"), RW0_rdata_0, UInt<1>("h0"))
 
   extmodule my_sram_1rw_64x8 :
-    input CE : Clock
     input A : UInt<6>
+    input CE : Clock
     input I : UInt<8>
     output O : UInt<8>
     input CSB : UInt<1>
@@ -1425,8 +1386,8 @@ class RocketChipTest extends MacroCompilerSpec with HasSRAMGenerator {
 """
 circuit T_2172_ext :
   module tag_array_ext :
-    input RW0_clk : Clock
     input RW0_addr : UInt<6>
+    input RW0_clk : Clock
     input RW0_wdata : UInt<80>
     output RW0_rdata : UInt<80>
     input RW0_en : UInt<1>
@@ -1461,8 +1422,8 @@ circuit T_2172_ext :
     RW0_rdata <= mux(UInt<1>("h1"), RW0_rdata_0, UInt<1>("h0"))
 
   extmodule SRAM1RW64x32 :
-    input clk : Clock
     input addr : UInt<6>
+    input clk : Clock
     input din : UInt<32>
     output dout : UInt<32>
     input write_en : UInt<1>
@@ -1470,8 +1431,8 @@ circuit T_2172_ext :
     defname = SRAM1RW64x32
 
   module T_1090_ext :
-    input RW0_clk : Clock
     input RW0_addr : UInt<9>
+    input RW0_clk : Clock
     input RW0_wdata : UInt<64>
     output RW0_rdata : UInt<64>
     input RW0_en : UInt<1>
@@ -1493,8 +1454,8 @@ circuit T_2172_ext :
     RW0_rdata <= mux(UInt<1>("h1"), RW0_rdata_0, UInt<1>("h0"))
 
   extmodule SRAM1RW512x32 :
-    input clk : Clock
     input addr : UInt<9>
+    input clk : Clock
     input din : UInt<32>
     output dout : UInt<32>
     input write_en : UInt<1>
@@ -1503,8 +1464,8 @@ circuit T_2172_ext :
 
 
   module T_406_ext :
-    input RW0_clk : Clock
     input RW0_addr : UInt<9>
+    input RW0_clk : Clock
     input RW0_wdata : UInt<64>
     output RW0_rdata : UInt<64>
     input RW0_en : UInt<1>
@@ -1563,8 +1524,8 @@ circuit T_2172_ext :
     RW0_rdata <= mux(UInt<1>("h1"), RW0_rdata_0, UInt<1>("h0"))
 
   extmodule SRAM1RW512x8 :
-    input clk : Clock
     input addr : UInt<9>
+    input clk : Clock
     input din : UInt<8>
     output dout : UInt<8>
     input write_en : UInt<1>
@@ -1573,13 +1534,13 @@ circuit T_2172_ext :
 
 
   module T_2172_ext :
-    input W0_clk : Clock
     input W0_addr : UInt<6>
+    input W0_clk : Clock
     input W0_data : UInt<88>
     input W0_en : UInt<1>
     input W0_mask : UInt<4>
-    input R0_clk : Clock
     input R0_addr : UInt<6>
+    input R0_clk : Clock
     output R0_data : UInt<88>
     input R0_en : UInt<1>
 
@@ -1619,11 +1580,11 @@ circuit T_2172_ext :
     R0_data <= mux(UInt<1>("h1"), R0_data_0, UInt<1>("h0"))
 
   extmodule SRAM2RW64x32 :
-    input portA_clk : Clock
     input portA_addr : UInt<6>
+    input portA_clk : Clock
     output portA_dout : UInt<32>
-    input portB_clk : Clock
     input portB_addr : UInt<6>
+    input portB_clk : Clock
     input portB_din : UInt<32>
     input portB_write_en : UInt<1>
 

--- a/macros/src/test/scala/SynFlops.scala
+++ b/macros/src/test/scala/SynFlops.scala
@@ -112,11 +112,11 @@ class Synflops_SplitPorts_Read_Write extends MacroCompilerSpec with HasSRAMGener
 """
 circuit target_memory :
   module target_memory :
-    input outerB_clk : Clock
     input outerB_addr : UInt<11>
+    input outerB_clk : Clock
     output outerB_dout : UInt<8>
-    input outerA_clk : Clock
     input outerA_addr : UInt<11>
+    input outerA_clk : Clock
     input outerA_din : UInt<8>
     input outerA_write_en : UInt<1>
 """
@@ -151,11 +151,11 @@ circuit target_memory :
 
   override def generateFooterPorts =
 """
-    input innerA_clk : Clock
     input innerA_addr : UInt<10>
+    input innerA_clk : Clock
     output innerA_dout : UInt<8>
-    input innerB_clk : Clock
     input innerB_addr : UInt<10>
+    input innerB_clk : Clock
     input innerB_din : UInt<8>
     input innerB_write_en : UInt<1>
 """
@@ -221,11 +221,11 @@ class Synflops_SplitPorts_MaskedMem_Read_MaskedWrite extends MacroCompilerSpec w
 """
 circuit target_memory :
   module target_memory :
-    input outerB_clk : Clock
     input outerB_addr : UInt<11>
+    input outerB_clk : Clock
     output outerB_dout : UInt<8>
-    input outerA_clk : Clock
     input outerA_addr : UInt<11>
+    input outerA_clk : Clock
     input outerA_din : UInt<8>
     input outerA_write_en : UInt<1>
     input outerA_mask : UInt<1>
@@ -263,11 +263,11 @@ circuit target_memory :
 
   override def generateFooterPorts =
 """
-    input innerA_clk : Clock
     input innerA_addr : UInt<10>
+    input innerA_clk : Clock
     output innerA_dout : UInt<8>
-    input innerB_clk : Clock
     input innerB_addr : UInt<10>
+    input innerB_clk : Clock
     input innerB_din : UInt<8>
     input innerB_write_en : UInt<1>
     input innerB_mask : UInt<8>

--- a/tapeout/src/main/scala/transforms/ConvertToExtModPass.scala
+++ b/tapeout/src/main/scala/transforms/ConvertToExtModPass.scala
@@ -25,8 +25,8 @@ class ConvertToExtModPass(classify: (Module) => Boolean) extends Pass {
   }
 }
 class ConvertToExtMod(classify: (Module) => Boolean) extends Transform with SeqTransformBased {
-  def inputForm = MidForm
-  def outputForm = MidForm
+  def inputForm = HighForm
+  def outputForm = HighForm
   def transforms = Seq(new ConvertToExtModPass(classify))
 
   def execute(state: CircuitState): CircuitState = {

--- a/tapeout/src/main/scala/transforms/RemoveUnusedModules.scala
+++ b/tapeout/src/main/scala/transforms/RemoveUnusedModules.scala
@@ -11,8 +11,8 @@ import firrtl.transforms.DontTouchAnnotation
 // Removes all the unused modules in a circuit by recursing through every
 // instance (starting at the main module)
 class RemoveUnusedModules extends Transform {
-  def inputForm = MidForm
-  def outputForm = MidForm
+  def inputForm = HighForm
+  def outputForm = HighForm
 
   def execute(state: CircuitState): CircuitState = {
     val modulesByName = state.circuit.modules.map{


### PR DESCRIPTION
This is a multi-feature PR with each commit being a small feature.

Chronologically the features are:

- Allow SRAMs to have ports without associated clocks. This is the typical kind of SRAM encountered in the wild. Ideally we would put some compile-time assertion that the chisel memories read and write clocks are the same but I'm leaving this as a TODO for now. We simply connect one of the clocks to the SRAM clock port.
- Next we fix the default cost model. Cost is changed to a double from BigInt to avoid funny integer off by one junk. Then we drop the last term that was causing the inverse of expected cost. In rocket-chip designs with a commercial SRAM compiler this now picks the largest possible memory whereas the previous version of this metric picked the smallest possible memories.
- Then we improve MacroCompilers handling of generative SRAM compilers. We filter the SRAMs by number of ports and mask compatibility and then by ability to provide integral mappings for the proposed design memory. This results in a large selection but was kept in for fancy cost metrics to utilize. The runtime is a few seconds with all the integral mappings and is not noticeably longer than only the largest mapping.
- Finally we change the input forms of the passes used by GenerateTop such that we replace the SeqMems after we have removed the TestHarness. This avoids creating a conf with very large memories that would break downstream tools, such as MacroCompiler.