### PR TITLE
Workaround replseqmem in testharness

### DIFF
--- a/tapeout/src/main/scala/transforms/RenameModulesAndInstances.scala
+++ b/tapeout/src/main/scala/transforms/RenameModulesAndInstances.scala
@@ -30,7 +30,10 @@ class RenameModulesAndInstances(rename: (String) => String) extends Transform {
     val modulesx = c.modules.map {
       case m: ExtModule =>
         myRenames.record(ModuleTarget(c.main, m.name), ModuleTarget(c.main, rename(m.name)))
-        m.copy(name = rename(m.name))
+        if(m.name.endsWith("_ext"))
+          m.copy(name = rename(m.name), defname = rename(m.defname))
+        else
+          m.copy(name = rename(m.name))
       case m: Module =>
         myRenames.record(ModuleTarget(c.main, m.name), ModuleTarget(c.main, rename(m.name)))
         new Module(m.info, rename(m.name), m.ports, renameInstances(m.body))


### PR DESCRIPTION
This was used on the EAGLEX tapeout to work around name conflicts in the test harness SRAMs