### PR TITLE
Filter all EmittedAnnotations from JSON emission

### DIFF
--- a/tapeout/src/main/scala/transforms/Generate.scala
+++ b/tapeout/src/main/scala/transforms/Generate.scala
@@ -3,6 +3,7 @@ package barstools.tapeout.transforms
 import firrtl._
 import firrtl.ir._
 import firrtl.annotations._
+import firrtl.stage.FirrtlCircuitAnnotation
 import firrtl.passes.Pass
 
 import java.io.File
@@ -160,6 +161,7 @@ sealed trait GenerateTopAndHarnessApp extends LazyLogging { this: App =>
           val outputFile = new java.io.PrintWriter(annoFile)
           outputFile.write(JsonProtocol.serialize(x.circuitState.annotations.filter(_ match {
             case ea: EmittedAnnotation[_] => false
+            case fca: FirrtlCircuitAnnotation => false
             case _ => true
           })))
           outputFile.close()
@@ -189,6 +191,7 @@ sealed trait GenerateTopAndHarnessApp extends LazyLogging { this: App =>
           val outputFile = new java.io.PrintWriter(annoFile)
           outputFile.write(JsonProtocol.serialize(x.circuitState.annotations.filter(_ match {
             case ea: EmittedAnnotation[_] => false
+            case fca: FirrtlCircuitAnnotation => false
             case _ => true
           })))
           outputFile.close()

--- a/tapeout/src/main/scala/transforms/Generate.scala
+++ b/tapeout/src/main/scala/transforms/Generate.scala
@@ -159,7 +159,7 @@ sealed trait GenerateTopAndHarnessApp extends LazyLogging { this: App =>
         tapeoutOptions.topAnnoOut.foreach { annoFile =>
           val outputFile = new java.io.PrintWriter(annoFile)
           outputFile.write(JsonProtocol.serialize(x.circuitState.annotations.filter(_ match {
-            case EmittedVerilogCircuitAnnotation(_) => false
+            case ea: EmittedAnnotation[_] => false
             case _ => true
           })))
           outputFile.close()
@@ -188,7 +188,7 @@ sealed trait GenerateTopAndHarnessApp extends LazyLogging { this: App =>
         tapeoutOptions.harnessAnnoOut.foreach { annoFile =>
           val outputFile = new java.io.PrintWriter(annoFile)
           outputFile.write(JsonProtocol.serialize(x.circuitState.annotations.filter(_ match {
-            case EmittedVerilogCircuitAnnotation(_) => false
+            case ea: EmittedAnnotation[_] => false
             case _ => true
           })))
           outputFile.close()


### PR DESCRIPTION
Some revisions to the FIRRTL compiler have caused new forms of `EmittedAnnotation` to be created. Since these are already emitted elsewhere, it is not necessary to emit them into the JSON file.

This change fixes the heap overflow issues associated with bumping FIRRTL.