### PR TITLE
Remove large annotations

### DIFF
--- a/tapeout/src/main/scala/transforms/Generate.scala
+++ b/tapeout/src/main/scala/transforms/Generate.scala
@@ -202,13 +202,7 @@ sealed trait GenerateTopAndHarnessApp extends LazyLogging { this: App =>
     annoFile.foreach { annoPath =>
       val outputFile = new java.io.PrintWriter(annoPath)
       outputFile.write(JsonProtocol.serialize(res.circuitState.annotations.filter(_ match {
-        case DeletedAnnotation(_, anno) =>
-          anno match {
-            case ec: EmittedComponent => false
-            case ea: EmittedAnnotation[_] => false
-            case fca: FirrtlCircuitAnnotation => false
-            case _ => true
-          }
+        case da: DeletedAnnotation => false
         case ec: EmittedComponent => false
         case ea: EmittedAnnotation[_] => false
         case fca: FirrtlCircuitAnnotation => false

--- a/tapeout/src/main/scala/transforms/Generate.scala
+++ b/tapeout/src/main/scala/transforms/Generate.scala
@@ -202,6 +202,14 @@ sealed trait GenerateTopAndHarnessApp extends LazyLogging { this: App =>
     annoFile.foreach { annoPath =>
       val outputFile = new java.io.PrintWriter(annoPath)
       outputFile.write(JsonProtocol.serialize(res.circuitState.annotations.filter(_ match {
+        case DeletedAnnotation(_, anno) =>
+          anno match {
+            case ec: EmittedComponent => false
+            case ea: EmittedAnnotation[_] => false
+            case fca: FirrtlCircuitAnnotation => false
+            case _ => true
+          }
+        case ec: EmittedComponent => false
         case ea: EmittedAnnotation[_] => false
         case fca: FirrtlCircuitAnnotation => false
         case _ => true


### PR DESCRIPTION
This PR removes large annotations that were deleted but kept inside of the output `json`. This fixes an OOM error on `beagle`, but I suspect it will happen on other very large designs.

Do we need any of these annotations for other tooling that happens after the `Generate...` steps?