### PR TITLE
Fix MacroCompiler for CE-less Library Memories

### DIFF
--- a/macros/src/main/scala/MacroCompiler.scala
+++ b/macros/src/main/scala/MacroCompiler.scala
@@ -517,13 +517,16 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
                 /* Palmer: If we're expected to provide mask ports without a
                  * memory that actually has them then we can use the
                  * write enable port instead of the mask port. */
-                stmts += connectPorts(andAddrMatch(and(memWriteEnable, memMask)),
-                                      we, we_polarity)
                 chipEnable match {
                   case Some(PolarizedPort(en, en_polarity)) => {
+                    stmts += connectPorts(andAddrMatch(and(memWriteEnable, memMask)),
+                                      we, we_polarity)
                     stmts += connectPorts(andAddrMatch(memChipEnable), en, en_polarity)
                   }
-                  case _ => // TODO: do we care about the case where mem has chipEnable but lib doesn't?
+                  case _ => {
+                    stmts += connectPorts(andAddrMatch(and(and(memWriteEnable, memChipEnable), memMask)),
+                                      we, we_polarity)
+                  }
                 }
               } else {
                 System.err.println("cannot emulate multi-bit mask ports with write enable")

--- a/macros/src/main/scala/MacroCompiler.scala
+++ b/macros/src/main/scala/MacroCompiler.scala
@@ -495,7 +495,7 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
             case (Some(PolarizedPort(mem, _)), Some(PolarizedPort(lib, lib_polarity))) =>
               stmts += connectPorts(andAddrMatch(WRef(mem)), lib, lib_polarity)
             case (None, Some(PolarizedPort(lib, lib_polarity))) =>
-              stmts += connectPorts(andAddrMatch(not(memWriteEnable)), lib, lib_polarity)
+              stmts += connectPorts(andAddrMatch(and(not(memWriteEnable), memChipEnable)), lib, lib_polarity)
           }
 
           /* Palmer: This is actually the memory compiler: it figures out how to

--- a/macros/src/test/resources/lib-WriteEnableTest.json
+++ b/macros/src/test/resources/lib-WriteEnableTest.json
@@ -1,0 +1,24 @@
+[
+  {
+    "type" : "sram",
+    "name" : "fake_mem",
+    "width" : 64,
+    "depth" : "4096",
+    "mux" : 4,
+    "family" : "1rw",
+    "ports" : [ {
+        "address port name" : "addr",
+        "address port polarity" : "active high",
+        "clock port name" : "clk",
+        "clock port polarity" : "positive edge",
+        "write enable port name" : "wen",
+        "write enable port polarity" : "active high",
+        "read enable port name" : "ren",
+        "read enable port polarity" : "active high",
+        "output port name" : "dataout",
+        "output port polarity" : "active high",
+        "input port name" : "datain",
+        "input port polarity" : "active high"
+    } ]
+  }
+]

--- a/macros/src/test/scala/SpecificExamples.scala
+++ b/macros/src/test/scala/SpecificExamples.scala
@@ -22,6 +22,76 @@ class GenerateSomeVerilog extends MacroCompilerSpec with HasSRAMGenerator with H
   }
 }
 
+class WriteEnableTest extends MacroCompilerSpec with HasSRAMGenerator {
+  val mem = s"mem-WriteEnableTest.json" // mem. you want to create
+  val lib = s"lib-WriteEnableTest.json" // lib. of mems to create it
+  val v = s"WriteEnableTest.json"
+
+  override val libPrefix = "macros/src/test/resources"
+
+  val memSRAMs = mdf.macrolib.Utils.readMDFFromString(
+"""
+[ {
+  "type" : "sram",
+  "name" : "cc_banks_0_ext",
+  "width" : 64,
+  "depth" : "4096",
+  "mux" : 1,
+  "ports" : [ {
+    "address port name" : "RW0_addr",
+    "address port polarity" : "active high",
+    "clock port name" : "RW0_clk",
+    "clock port polarity" : "positive edge",
+    "write enable port name" : "RW0_wmode",
+    "write enable port polarity" : "active high",
+    "chip enable port name" : "RW0_en",
+    "chip enable port polarity" : "active high",
+    "output port name" : "RW0_rdata",
+    "output port polarity" : "active high",
+    "input port name" : "RW0_wdata",
+    "input port polarity" : "active high"
+  } ],
+  "family" : "1rw"
+} ]
+""").getOrElse(List())
+
+  writeToMem(mem, memSRAMs)
+
+  val output =
+"""
+  circuit cc_banks_0_ext :
+    module cc_banks_0_ext :
+      input RW0_addr : UInt<12>
+      input RW0_clk : Clock
+      input RW0_wdata : UInt<64>
+      output RW0_rdata : UInt<64>
+      input RW0_en : UInt<1>
+      input RW0_wmode : UInt<1>
+
+      inst mem_0_0 of fake_mem
+      mem_0_0.clk <= RW0_clk
+      mem_0_0.addr <= RW0_addr
+      node RW0_rdata_0_0 = bits(mem_0_0.dataout, 63, 0)
+      mem_0_0.datain <= bits(RW0_wdata, 63, 0)
+      mem_0_0.ren <= and(and(not(RW0_wmode), RW0_en), UInt<1>("h1"))
+      mem_0_0.wen <= and(and(and(RW0_wmode, RW0_en), UInt<1>("h1")), UInt<1>("h1"))
+      node RW0_rdata_0 = RW0_rdata_0_0
+      RW0_rdata <= mux(UInt<1>("h1"), RW0_rdata_0, UInt<1>("h0"))
+
+    extmodule fake_mem :
+      input addr : UInt<12>
+      input clk : Clock
+      input datain : UInt<64>
+      output dataout : UInt<64>
+      input ren : UInt<1>
+      input wen : UInt<1>
+
+      defname = fake_mem
+"""
+
+  compileExecuteAndTest(mem, lib, v, output)
+}
+
 class MaskPortTest extends MacroCompilerSpec with HasSRAMGenerator {
   val mem = s"mem-MaskPortTest.json" // mem. you want to create
   val lib = s"lib-MaskPortTest.json" // lib. of mems to create it


### PR DESCRIPTION
If a memory doesn't have a mask and doesn't have a chip enable, make sure that you use the `mem` chip enable to connect to the `we` port on the `lib` memory. Fixes a bug where the `lib` `we` signal would be tied to the `mem` `wmode` signal but then the macro would have no `en` signal connected to it.