### PR TITLE
Correctly specify width of default zero output value

### DIFF
--- a/macros/src/main/scala/MacroCompiler.scala
+++ b/macros/src/main/scala/MacroCompiler.scala
@@ -549,11 +549,12 @@ class MacroCompilerPass(mems: Option[Seq[Macro]],
       }
     }
     // Connect mem outputs
+    val zeroOutputValue: Expression = UIntLiteral(0, IntWidth(mem.src.width))
     mem.src.ports foreach { port =>
       port.output match {
         case Some(PolarizedPort(mem, _)) => outputs get mem match {
           case Some(select) =>
-            val output = (select foldRight (zero: Expression)) {
+            val output = (select foldRight (zeroOutputValue)) {
               case ((cond, tval), fval) => Mux(cond, tval, fval, fval.tpe) }
             stmts += Connect(NoInfo, WRef(mem), output)
           case None =>


### PR DESCRIPTION
I believe this should fix the bug posted by Young Kim to the mailing list yesterday (2/10). The `mux` expression must have matching widths for its arguments. I think FIRRTL should be giving better error messages, but this should be the correct fix.

>The error message is:
…/chipyard/sims/verilator/generated-src/freechips.rocketchip.system.DefaultTestConfig/freechips.rocketchip.system.DefaultTestConfig.harness.mems.v:842: Operator COND expects 64 bits on the Conditional False, but Conditional False's CONST '1'h0' generates 1 bits.
                ... Use "/* verilator lint_off WIDTH */" and lint_on around source to disable this message.
%Error: Exiting due to 1 warning(s)