### PR TITLE
Add IO cell models

### DIFF
--- a/iocell/src/main/resources/barstools/iocell/vsrc/Analog.v
+++ b/iocell/src/main/resources/barstools/iocell/vsrc/Analog.v
@@ -1,0 +1,11 @@
+// See LICENSE for license details
+
+`timescale 1ns/1ps
+
+module AnalogConst #(CONST, WIDTH) (
+    output [WIDTH-1:0] io
+);
+
+    assign io = CONST;
+
+endmodule

--- a/iocell/src/main/resources/barstools/iocell/vsrc/IOCell.v
+++ b/iocell/src/main/resources/barstools/iocell/vsrc/IOCell.v
@@ -2,7 +2,7 @@
 
 `timescale 1ns/1ps
 
-module ExampleAnalogIOCell(
+module GenericAnalogIOCell(
     inout pad,
     inout core
 );
@@ -12,7 +12,7 @@ module ExampleAnalogIOCell(
 
 endmodule
 
-module ExampleDigitalGPIOCell(
+module GenericDigitalGPIOCell(
     inout pad,
     output i,
     input ie,
@@ -25,7 +25,7 @@ module ExampleDigitalGPIOCell(
 
 endmodule
 
-module ExampleDigitalInIOCell(
+module GenericDigitalInIOCell(
     input pad,
     output i,
     input ie
@@ -35,7 +35,7 @@ module ExampleDigitalInIOCell(
 
 endmodule
 
-module ExampleDigitalOutIOCell(
+module GenericDigitalOutIOCell(
     output pad,
     input o,
     output oe

--- a/iocell/src/main/resources/barstools/iocell/vsrc/IOCell.v
+++ b/iocell/src/main/resources/barstools/iocell/vsrc/IOCell.v
@@ -1,0 +1,46 @@
+// See LICENSE for license details
+
+`timescale 1ns/1ps
+
+module ExampleAnalogIOCell(
+    inout pad,
+    inout core
+);
+
+    assign core = 1'bz;
+    assign pad = core;
+
+endmodule
+
+module ExampleDigitalGPIOCell(
+    inout pad,
+    output i,
+    input ie,
+    input o,
+    input oe
+);
+
+    assign pad = oe ? o : 1'bz;
+    assign i = ie ? pad : 1'b0;
+
+endmodule
+
+module ExampleDigitalInIOCell(
+    input pad,
+    output i,
+    input ie
+);
+
+    assign i = ie ? pad : 1'b0;
+
+endmodule
+
+module ExampleDigitalOutIOCell(
+    output pad,
+    input o,
+    output oe
+);
+
+    assign pad = oe ? o : 1'bz;
+
+endmodule

--- a/iocell/src/main/scala/chisel/Analog.scala
+++ b/iocell/src/main/scala/chisel/Analog.scala
@@ -1,0 +1,16 @@
+// See LICENSE for license details
+
+package barstools.iocell.chisel
+
+import chisel3._
+import chisel3.util.{HasBlackBoxResource}
+import chisel3.experimental.{Analog, IntParam}
+
+class AnalogConst(value: Int, width: Int = 1) extends BlackBox(Map("CONST" -> IntParam(value), "WIDTH" -> IntParam(width))) with HasBlackBoxResource{
+  val io = IO(new Bundle {val io = Analog(width.W) } )
+  addResource("/barstools/iocell/vsrc/Analog.v")
+}
+
+object AnalogConst {
+  def apply(value: Int, width: Int = 1) = Module(new AnalogConst(value, width)).io.io
+}

--- a/iocell/src/main/scala/chisel/IOCell.scala
+++ b/iocell/src/main/scala/chisel/IOCell.scala
@@ -1,0 +1,185 @@
+// See LICENSE for license details
+
+package barstools.iocell.chisel
+
+import chisel3._
+import chisel3.util.{Cat, HasBlackBoxResource}
+import chisel3.experimental.{Analog, DataMirror}
+
+class AnalogIOCellBundle extends Bundle {
+  val pad = Analog(1.W)
+  val core = Analog(1.W)
+}
+
+class DigitalGPIOCellBundle extends Bundle {
+  val pad = Analog(1.W)
+  val i = Output(Bool())
+  val ie = Input(Bool())
+  val o = Input(Bool())
+  val oe = Input(Bool())
+}
+
+class DigitalOutIOCellBundle extends Bundle {
+  val pad = Output(Bool())
+  val o = Input(Bool())
+  val oe = Input(Bool())
+}
+
+class DigitalInIOCellBundle extends Bundle {
+  val pad = Input(Bool())
+  val i = Output(Bool())
+  val ie = Input(Bool())
+}
+
+abstract class IOCell extends BlackBox with HasBlackBoxResource
+
+abstract class AnalogIOCell extends IOCell {
+  val io: AnalogIOCellBundle
+}
+
+abstract class DigitalGPIOCell extends IOCell {
+  val io: DigitalGPIOCellBundle
+}
+
+abstract class DigitalInIOCell extends IOCell {
+  val io: DigitalInIOCellBundle
+}
+
+abstract class DigitalOutIOCell extends IOCell {
+  val io: DigitalOutIOCellBundle
+}
+
+class ExampleAnalogIOCell extends AnalogIOCell {
+  val io = IO(new AnalogIOCellBundle)
+  addResource("/barstools/iocell/vsrc/IOCell.v")
+}
+
+class ExampleDigitalGPIOCell extends DigitalGPIOCell {
+  val io = IO(new DigitalGPIOCellBundle)
+  addResource("/barstools/iocell/vsrc/IOCell.v")
+}
+
+class ExampleDigitalInIOCell extends DigitalInIOCell {
+  val io = IO(new DigitalInIOCellBundle)
+  addResource("/barstools/iocell/vsrc/IOCell.v")
+}
+
+class ExampleDigitalOutIOCell extends DigitalOutIOCell {
+  val io = IO(new DigitalOutIOCellBundle)
+  addResource("/barstools/iocell/vsrc/IOCell.v")
+}
+
+object IOCell {
+
+  def exampleAnalog() = Module(new ExampleAnalogIOCell)
+  def exampleGPIO() = Module(new ExampleDigitalGPIOCell)
+  def exampleInput() = Module(new ExampleDigitalInIOCell)
+  def exampleOutput() = Module(new ExampleDigitalOutIOCell)
+
+  def generateRaw[T <: Data](signal: T,
+    inFn: () => DigitalInIOCell = IOCell.exampleInput,
+    outFn: () => DigitalOutIOCell = IOCell.exampleOutput,
+    anaFn: () => AnalogIOCell = IOCell.exampleAnalog): (T, Seq[IOCell]) =
+  {
+    (signal match {
+      case signal: Analog => {
+        require(signal.getWidth <= 1, "Analogs wider than 1 bit are not supported because we can't bit Analogs (https://github.com/freechipsproject/chisel3/issues/536)")
+        if (signal.getWidth == 0) {
+          (Analog(0.W), Seq())
+        } else {
+          val iocell = anaFn()
+          iocell.io.core <> signal
+          (iocell.io.pad, Seq(iocell))
+        }
+      }
+      case signal: Clock => {
+        DataMirror.specifiedDirectionOf(signal) match {
+          case SpecifiedDirection.Input => {
+            val iocell = inFn()
+            signal := iocell.io.i.asClock
+            iocell.io.ie := true.B
+            val ck = Wire(Clock())
+            iocell.io.pad := ck.asUInt.asBool
+            (ck, Seq(iocell))
+          }
+          case SpecifiedDirection.Output => {
+            val iocell = outFn()
+            iocell.io.o := signal.asUInt.asBool
+            iocell.io.oe := true.B
+            (iocell.io.pad.asClock, Seq(iocell))
+          }
+          case _ => throw new Exception("Unknown direction")
+        }
+      }
+      // TODO we may not actually need Bool (it is probably covered by Bits)
+      case signal: Bool => {
+        DataMirror.specifiedDirectionOf(signal) match {
+          case SpecifiedDirection.Input => {
+            val iocell = inFn()
+            signal := iocell.io.i
+            iocell.io.ie := true.B
+            (iocell.io.pad, Seq(iocell))
+          }
+          case SpecifiedDirection.Output => {
+            val iocell = outFn()
+            iocell.io.o := signal
+            iocell.io.oe := true.B
+            (iocell.io.pad, Seq(iocell))
+          }
+          case _ => throw new Exception("Unknown direction")
+        }
+      }
+      case signal: Bits => {
+        DataMirror.specifiedDirectionOf(signal) match {
+          case SpecifiedDirection.Input => {
+            val wire = Wire(chiselTypeOf(signal))
+            val iocells = wire.asBools.map { w =>
+              val iocell = inFn()
+              iocell.io.pad := w
+              iocell.io.ie := true.B
+              iocell
+            }
+            if (iocells.size > 0) {
+              signal := Cat(iocells.map(_.io.i).reverse)
+            }
+            (wire, iocells)
+          }
+          case SpecifiedDirection.Output => {
+            val iocells = signal.asBools.map { b =>
+              val iocell = outFn()
+              iocell.io.o := b
+              iocell.io.oe := true.B
+              iocell
+            }
+            if (iocells.size > 0) {
+              (Cat(iocells.map(_.io.pad).reverse), iocells)
+            } else {
+              (Wire(Bits(0.W)), iocells)
+            }
+          }
+          case _ => throw new Exception("Unknown direction")
+        }
+      }
+      case signal: Vec[_] => {
+        val wire = Wire(chiselTypeOf(signal))
+        val iocells = signal.zip(wire).foldLeft(Seq.empty[IOCell]) { case (total, (sig, w)) =>
+          val (pad, ios) = IOCell.generateRaw(sig, inFn, outFn, anaFn)
+          w <> pad
+          total ++ ios
+        }
+        (wire, iocells)
+      }
+      case signal: Record => {
+        val wire = Wire(chiselTypeOf(signal))
+        val iocells = signal.elements.foldLeft(Seq.empty[IOCell]) { case (total, (name, sig)) =>
+          val (pad, ios) = IOCell.generateRaw(sig, inFn, outFn, anaFn)
+          wire.elements(name) <> pad
+          total ++ ios
+        }
+        (wire, iocells)
+      }
+      case _ => { throw new Exception("Oops, I don't know how to handle this signal.") }
+    }).asInstanceOf[(T, Seq[IOCell])]
+  }
+
+}

--- a/iocell/src/main/scala/chisel/IOCell.scala
+++ b/iocell/src/main/scala/chisel/IOCell.scala
@@ -85,7 +85,7 @@ abstract class DigitalOutIOCell extends IOCell {
 // implementation of an IO cell. For building a real chip, it is important to implement
 // and use similar classes which wrap the foundry-specific IO cells.
 
-trait GenericIOCell extends HasBlackBoxResource {
+trait IsGenericIOCell extends HasBlackBoxResource {
   addResource("/barstools/iocell/vsrc/IOCell.v")
 }
 
@@ -196,7 +196,10 @@ object IOCell {
             case ActualDirection.Input => {
               val iocells = padSignal.asBools.zipWithIndex.map { case (sig, i) =>
                 val iocell = inFn()
-                name.foreach(n => iocell.suggestName(n + "_" + i))
+                // Note that we are relying on chisel deterministically naming this in the index order (which it does)
+                // This has the side-effect of naming index 0 with no _0 suffix, which is how chisel names other signals
+                // An alternative solution would be to suggestName(n + "_" + i)
+                name.foreach(n => iocell.suggestName(n))
                 iocell.io.pad := sig
                 iocell.io.ie := true.B
                 iocell
@@ -208,7 +211,10 @@ object IOCell {
             case ActualDirection.Output => {
               val iocells = coreSignal.asBools.zipWithIndex.map { case (sig, i) =>
                 val iocell = outFn()
-                name.foreach(n => iocell.suggestName(n + "_" + i))
+                // Note that we are relying on chisel deterministically naming this in the index order (which it does)
+                // This has the side-effect of naming index 0 with no _0 suffix, which is how chisel names other signals
+                // An alternative solution would be to suggestName(n + "_" + i)
+                name.foreach(n => iocell.suggestName(n))
                 iocell.io.o := sig
                 iocell.io.oe := true.B
                 iocell

--- a/iocell/src/main/scala/chisel/IOCell.scala
+++ b/iocell/src/main/scala/chisel/IOCell.scala
@@ -49,37 +49,37 @@ abstract class DigitalOutIOCell extends IOCell {
   val io: DigitalOutIOCellBundle
 }
 
-class ExampleAnalogIOCell extends AnalogIOCell {
+class GenericAnalogIOCell extends AnalogIOCell {
   val io = IO(new AnalogIOCellBundle)
   addResource("/barstools/iocell/vsrc/IOCell.v")
 }
 
-class ExampleDigitalGPIOCell extends DigitalGPIOCell {
+class GenericDigitalGPIOCell extends DigitalGPIOCell {
   val io = IO(new DigitalGPIOCellBundle)
   addResource("/barstools/iocell/vsrc/IOCell.v")
 }
 
-class ExampleDigitalInIOCell extends DigitalInIOCell {
+class GenericDigitalInIOCell extends DigitalInIOCell {
   val io = IO(new DigitalInIOCellBundle)
   addResource("/barstools/iocell/vsrc/IOCell.v")
 }
 
-class ExampleDigitalOutIOCell extends DigitalOutIOCell {
+class GenericDigitalOutIOCell extends DigitalOutIOCell {
   val io = IO(new DigitalOutIOCellBundle)
   addResource("/barstools/iocell/vsrc/IOCell.v")
 }
 
 object IOCell {
 
-  def exampleAnalog() = Module(new ExampleAnalogIOCell)
-  def exampleGPIO() = Module(new ExampleDigitalGPIOCell)
-  def exampleInput() = Module(new ExampleDigitalInIOCell)
-  def exampleOutput() = Module(new ExampleDigitalOutIOCell)
+  def genericAnalog() = Module(new GenericAnalogIOCell)
+  def genericGPIO() = Module(new GenericDigitalGPIOCell)
+  def genericInput() = Module(new GenericDigitalInIOCell)
+  def genericOutput() = Module(new GenericDigitalOutIOCell)
 
   def generateIOFromSignal[T <: Data](coreSignal: T, name: Option[String] = None,
-    inFn: () => DigitalInIOCell = IOCell.exampleInput,
-    outFn: () => DigitalOutIOCell = IOCell.exampleOutput,
-    anaFn: () => AnalogIOCell = IOCell.exampleAnalog): (T, Seq[IOCell]) =
+    inFn: () => DigitalInIOCell = IOCell.genericInput,
+    outFn: () => DigitalOutIOCell = IOCell.genericOutput,
+    anaFn: () => AnalogIOCell = IOCell.genericAnalog): (T, Seq[IOCell]) =
   {
     val padSignal = IO(DataMirror.internal.chiselTypeClone[T](coreSignal))
     val iocells = IOCell.generateFromSignal(coreSignal, padSignal, name, inFn, outFn, anaFn)
@@ -87,9 +87,9 @@ object IOCell {
   }
 
   def generateFromSignal[T <: Data](coreSignal: T, padSignal: T, name: Option[String] = None,
-    inFn: () => DigitalInIOCell = IOCell.exampleInput,
-    outFn: () => DigitalOutIOCell = IOCell.exampleOutput,
-    anaFn: () => AnalogIOCell = IOCell.exampleAnalog): Seq[IOCell] =
+    inFn: () => DigitalInIOCell = IOCell.genericInput,
+    outFn: () => DigitalOutIOCell = IOCell.genericOutput,
+    anaFn: () => AnalogIOCell = IOCell.genericAnalog): Seq[IOCell] =
   {
     coreSignal match {
       case coreSignal: Analog => {


### PR DESCRIPTION
This is a work in progress (this doesn't even elaborate yet), but basically this is my goal for how we can connect the IO cells in the ChipTop chipyard layer while keeping most of the IO types consistent with their System counterparts. Obviously excluded in that objective are widgets like GPIOs which have multiple control signals that we want to drive the IO cells with.