### PR TITLE
Fix direction of output enable in output io cell

### DIFF
--- a/iocell/src/main/resources/barstools/iocell/vsrc/IOCell.v
+++ b/iocell/src/main/resources/barstools/iocell/vsrc/IOCell.v
@@ -38,7 +38,7 @@ endmodule
 module GenericDigitalOutIOCell(
     output pad,
     input o,
-    output oe
+    input oe
 );
 
     assign pad = oe ? o : 1'bz;


### PR DESCRIPTION
Previously they would simulate fine but synthesize into disconnected ports.