### PR TITLE
Fix InstanceTarget annotations in ReParentCircuit

### DIFF
--- a/tapeout/src/main/scala/barstools/tapeout/transforms/ReParentCircuit.scala
+++ b/tapeout/src/main/scala/barstools/tapeout/transforms/ReParentCircuit.scala
@@ -35,18 +35,26 @@ class ReParentCircuit extends Transform with DependencyAPIMigration {
     }
 
     val newAnnotations = newTopName.map({ topName =>
-      // Update InstanceTargets
-      def updateInstanceTarget(t: InstanceTarget): Option[InstanceTarget] = {
+      // Update InstanceTargets and ReferenceTargets
+      // Yes, these are identical functions, but the copy methods force separate implementations
+      def updateInstance(t: InstanceTarget): Option[InstanceTarget] = {
+        val idx = t.path.lastIndexWhere(_._2.value == topName)
+        if (idx == -1) Some(t.copy(circuit=topName)) else Some(t.copy(circuit=topName, module=topName, path=t.path.drop(idx+1)))
+      }
+      def updateReference(t: ReferenceTarget): Option[ReferenceTarget] = {
         val idx = t.path.lastIndexWhere(_._2.value == topName)
         if (idx == -1) Some(t.copy(circuit=topName)) else Some(t.copy(circuit=topName, module=topName, path=t.path.drop(idx+1)))
       }
 
       AnnotationSeq(state.annotations.toSeq.map({
         case x: SingleTargetAnnotation[InstanceTarget] if x.target.isInstanceOf[InstanceTarget] =>
-          updateInstanceTarget(x.target).map(y => x.duplicate(y))
+          updateInstance(x.target).map(y => x.duplicate(y))
+        case x: SingleTargetAnnotation[ReferenceTarget] if x.target.isInstanceOf[ReferenceTarget] =>
+          updateReference(x.target).map(y => x.duplicate(y))
         case x: MultiTargetAnnotation =>
           val newTargets: Seq[Seq[Option[Target]]] = x.targets.map(_.map({
-            case y: InstanceTarget => updateInstanceTarget(y)
+            case y: InstanceTarget => updateInstance(y)
+            case y: ReferenceTarget => updateReference(y)
             case y => Some(y)
           }))
           if (newTargets.flatten.forall(_.isDefined)) Some(x.duplicate(newTargets.map(_.map(_.get)))) else None


### PR DESCRIPTION
Currently `ReParentCircuit` doesn't change any `InstanceTarget` annotations at all, so all annotations on `InstanceTarget`s are pruned when copying the `CircuitState`. This change looks for any `InstanceTarget` that passes through the new parent and re-parents them, along with changing the circuit string for all `InstanceTarget` annotations.