### PR TITLE
Fix all warnings in barstool.macros._

### DIFF
--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -29,6 +29,10 @@ jobs:
     name: Documentation and formatting
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v10
       - name: Check Formatting
         run: sbt scalafmtCheckAll
 

--- a/.github/workflows/run-ci.yml
+++ b/.github/workflows/run-ci.yml
@@ -39,5 +39,6 @@ jobs:
   all_test_passed:
     name: "all tests passed"
     runs-on: ubuntu-latest
+    needs: [test, doc]
     steps:
       - run: echo Success

--- a/src/main/scala/barstools/macros/Utils.scala
+++ b/src/main/scala/barstools/macros/Utils.scala
@@ -15,28 +15,28 @@ object MacroCompilerMath {
 }
 
 class FirrtlMacroPort(port: MacroPort) {
-  val src = port
+  val src: MacroPort = port
 
-  val isReader = port.output.nonEmpty && port.input.isEmpty
-  val isWriter = port.input.nonEmpty && port.output.isEmpty
-  val isReadWriter = port.input.nonEmpty && port.output.nonEmpty
+  val isReader:     Boolean = port.output.nonEmpty && port.input.isEmpty
+  val isWriter:     Boolean = port.input.nonEmpty && port.output.isEmpty
+  val isReadWriter: Boolean = port.input.nonEmpty && port.output.nonEmpty
 
-  val addrType = UIntType(IntWidth(MacroCompilerMath.ceilLog2(port.depth.get).max(1)))
-  val dataType = UIntType(IntWidth(port.width.get))
-  val maskType = UIntType(IntWidth(port.width.get / port.effectiveMaskGran))
+  val addrType: UIntType = UIntType(IntWidth(MacroCompilerMath.ceilLog2(port.depth.get).max(1)))
+  val dataType: UIntType = UIntType(IntWidth(port.width.get))
+  val maskType: UIntType = UIntType(IntWidth(port.width.get / port.effectiveMaskGran))
 
   // Bundle representing this macro port.
-  val tpe = BundleType(
+  val tpe: BundleType = BundleType(
     Seq(Field(port.address.name, Flip, addrType)) ++
-      (port.clock.map(p => Field(p.name, Flip, ClockType))) ++
-      (port.input.map(p => Field(p.name, Flip, dataType))) ++
-      (port.output.map(p => Field(p.name, Default, dataType))) ++
-      (port.chipEnable.map(p => Field(p.name, Flip, BoolType))) ++
-      (port.readEnable.map(p => Field(p.name, Flip, BoolType))) ++
-      (port.writeEnable.map(p => Field(p.name, Flip, BoolType))) ++
-      (port.maskPort.map(p => Field(p.name, Flip, maskType)))
+      port.clock.map(p => Field(p.name, Flip, ClockType)) ++
+      port.input.map(p => Field(p.name, Flip, dataType)) ++
+      port.output.map(p => Field(p.name, Default, dataType)) ++
+      port.chipEnable.map(p => Field(p.name, Flip, BoolType)) ++
+      port.readEnable.map(p => Field(p.name, Flip, BoolType)) ++
+      port.writeEnable.map(p => Field(p.name, Flip, BoolType)) ++
+      port.maskPort.map(p => Field(p.name, Flip, maskType))
   )
-  val ports = tpe.fields.map(f =>
+  val ports: Seq[Port] = tpe.fields.map(f =>
     Port(
       NoInfo,
       f.name,
@@ -51,30 +51,30 @@ class FirrtlMacroPort(port: MacroPort) {
 
 // Reads an SRAMMacro and generates firrtl blackboxes.
 class Macro(srcMacro: SRAMMacro) {
-  val src = srcMacro
+  val src: SRAMMacro = srcMacro
 
-  val firrtlPorts = srcMacro.ports.map { new FirrtlMacroPort(_) }
+  val firrtlPorts: Seq[FirrtlMacroPort] = srcMacro.ports.map { new FirrtlMacroPort(_) }
 
-  val writers = firrtlPorts.filter(p => p.isWriter)
-  val readers = firrtlPorts.filter(p => p.isReader)
-  val readwriters = firrtlPorts.filter(p => p.isReadWriter)
+  val writers: Seq[FirrtlMacroPort] = firrtlPorts.filter(p => p.isWriter)
+  val readers: Seq[FirrtlMacroPort] = firrtlPorts.filter(p => p.isReader)
+  val readwriters: Seq[FirrtlMacroPort] = firrtlPorts.filter(p => p.isReadWriter)
 
-  val sortedPorts = writers ++ readers ++ readwriters
-  val extraPorts = srcMacro.extraPorts.map { p =>
+  val sortedPorts: Seq[FirrtlMacroPort] = writers ++ readers ++ readwriters
+  val extraPorts: Seq[(String, UIntLiteral)] = srcMacro.extraPorts.map { p =>
     assert(p.portType == Constant) // TODO: release it?
     val name = p.name
     val width = BigInt(p.width.toLong)
     val value = BigInt(p.value.toLong)
-    (name -> UIntLiteral(value, IntWidth(width)))
+    name -> UIntLiteral(value, IntWidth(width))
   }
 
   // Bundle representing this memory blackbox
-  val tpe = BundleType(firrtlPorts.flatMap(_.tpe.fields))
+  val tpe: BundleType = BundleType(firrtlPorts.flatMap(_.tpe.fields))
 
-  private val modPorts = (firrtlPorts.flatMap(_.ports)) ++
-    (extraPorts.map { case (name, value) => Port(NoInfo, name, Input, value.tpe) })
-  val blackbox = ExtModule(NoInfo, srcMacro.name, modPorts, srcMacro.name, Nil)
-  def module(body: Statement) = Module(NoInfo, srcMacro.name, modPorts, body)
+  private val modPorts = firrtlPorts.flatMap(_.ports) ++
+    extraPorts.map { case (name, value) => Port(NoInfo, name, Input, value.tpe) }
+  val blackbox: ExtModule = ExtModule(NoInfo, srcMacro.name, modPorts, srcMacro.name, Nil)
+  def module(body: Statement): Module = Module(NoInfo, srcMacro.name, modPorts, body)
 }
 
 object Utils {
@@ -87,7 +87,7 @@ object Utils {
   }
   // This utility reads a conf in and returns MDF like mdf.macrolib.Utils.readMDFFromPath
   def readConfFromPath(path: Option[String]): Option[Seq[mdf.macrolib.Macro]] = {
-    path.map((p) => Utils.readConfFromString(scala.io.Source.fromFile(p).mkString))
+    path.map(p => Utils.readConfFromString(FileUtils.getText(p)))
   }
   def readConfFromString(str: String): Seq[mdf.macrolib.Macro] = {
     MemConf.fromString(str).map { m: MemConf =>
@@ -102,13 +102,13 @@ object Utils {
     }
   }
   def portSpecToFamily(ports: Seq[MemPort]): String = {
-    val numR = ports.count(_ match { case ReadPort => true; case _ => false })
-    val numW = ports.count(_ match { case WritePort | MaskedWritePort => true; case _ => false })
-    val numRW = ports.count(_ match { case ReadWritePort | MaskedReadWritePort => true; case _ => false })
+    val numR = ports.count { case ReadPort => true; case _ => false }
+    val numW = ports.count { case WritePort | MaskedWritePort => true; case _ => false }
+    val numRW = ports.count { case ReadWritePort | MaskedReadWritePort => true; case _ => false }
     val numRStr = if (numR > 0) s"${numR}r" else ""
     val numWStr = if (numW > 0) s"${numW}w" else ""
     val numRWStr = if (numRW > 0) s"${numRW}rw" else ""
-    return numRStr + numWStr + numRWStr
+    numRStr + numWStr + numRWStr
   }
   // This translates between two represenations of ports
   def portSpecToMacroPort(width: Int, depth: BigInt, maskGran: Option[Int], ports: Seq[MemPort]): Seq[MacroPort] = {
@@ -116,76 +116,69 @@ object Utils {
     var numW = 0
     var numRW = 0
     ports.map {
-      _ match {
-        case ReadPort => {
-          val portName = s"R${numR}"
-          numR += 1
-          MacroPort(
-            width = Some(width),
-            depth = Some(depth),
-            address = PolarizedPort(s"${portName}_addr", ActiveHigh),
-            clock = Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
-            readEnable = Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
-            output = Some(PolarizedPort(s"${portName}_data", ActiveHigh))
-          )
-        }
-        case WritePort => {
-          val portName = s"W${numW}"
-          numW += 1
-          MacroPort(
-            width = Some(width),
-            depth = Some(depth),
-            address = PolarizedPort(s"${portName}_addr", ActiveHigh),
-            clock = Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
-            writeEnable = Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
-            input = Some(PolarizedPort(s"${portName}_data", ActiveHigh))
-          )
-        }
-        case MaskedWritePort => {
-          val portName = s"W${numW}"
-          numW += 1
-          MacroPort(
-            width = Some(width),
-            depth = Some(depth),
-            address = PolarizedPort(s"${portName}_addr", ActiveHigh),
-            clock = Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
-            writeEnable = Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
-            maskPort = Some(PolarizedPort(s"${portName}_mask", ActiveHigh)),
-            maskGran = maskGran,
-            input = Some(PolarizedPort(s"${portName}_data", ActiveHigh))
-          )
-        }
-        case ReadWritePort => {
-          val portName = s"RW${numRW}"
-          numRW += 1
-          MacroPort(
-            width = Some(width),
-            depth = Some(depth),
-            address = PolarizedPort(s"${portName}_addr", ActiveHigh),
-            clock = Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
-            chipEnable = Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
-            writeEnable = Some(PolarizedPort(s"${portName}_wmode", ActiveHigh)),
-            input = Some(PolarizedPort(s"${portName}_wdata", ActiveHigh)),
-            output = Some(PolarizedPort(s"${portName}_rdata", ActiveHigh))
-          )
-        }
-        case MaskedReadWritePort => {
-          val portName = s"RW${numRW}"
-          numRW += 1
-          MacroPort(
-            width = Some(width),
-            depth = Some(depth),
-            address = PolarizedPort(s"${portName}_addr", ActiveHigh),
-            clock = Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
-            chipEnable = Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
-            writeEnable = Some(PolarizedPort(s"${portName}_wmode", ActiveHigh)),
-            maskPort = Some(PolarizedPort(s"${portName}_wmask", ActiveHigh)),
-            maskGran = maskGran,
-            input = Some(PolarizedPort(s"${portName}_wdata", ActiveHigh)),
-            output = Some(PolarizedPort(s"${portName}_rdata", ActiveHigh))
-          )
-        }
-      }
+      case ReadPort =>
+        val portName = s"R$numR"
+        numR += 1
+        MacroPort(
+          width = Some(width),
+          depth = Some(depth),
+          address = PolarizedPort(s"${portName}_addr", ActiveHigh),
+          clock = Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
+          readEnable = Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
+          output = Some(PolarizedPort(s"${portName}_data", ActiveHigh))
+        )
+      case WritePort =>
+        val portName = s"W$numW"
+        numW += 1
+        MacroPort(
+          width = Some(width),
+          depth = Some(depth),
+          address = PolarizedPort(s"${portName}_addr", ActiveHigh),
+          clock = Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
+          writeEnable = Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
+          input = Some(PolarizedPort(s"${portName}_data", ActiveHigh))
+        )
+      case MaskedWritePort =>
+        val portName = s"W$numW"
+        numW += 1
+        MacroPort(
+          width = Some(width),
+          depth = Some(depth),
+          address = PolarizedPort(s"${portName}_addr", ActiveHigh),
+          clock = Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
+          writeEnable = Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
+          maskPort = Some(PolarizedPort(s"${portName}_mask", ActiveHigh)),
+          maskGran = maskGran,
+          input = Some(PolarizedPort(s"${portName}_data", ActiveHigh))
+        )
+      case ReadWritePort =>
+        val portName = s"RW$numRW"
+        numRW += 1
+        MacroPort(
+          width = Some(width),
+          depth = Some(depth),
+          address = PolarizedPort(s"${portName}_addr", ActiveHigh),
+          clock = Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
+          chipEnable = Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
+          writeEnable = Some(PolarizedPort(s"${portName}_wmode", ActiveHigh)),
+          input = Some(PolarizedPort(s"${portName}_wdata", ActiveHigh)),
+          output = Some(PolarizedPort(s"${portName}_rdata", ActiveHigh))
+        )
+      case MaskedReadWritePort =>
+        val portName = s"RW$numRW"
+        numRW += 1
+        MacroPort(
+          width = Some(width),
+          depth = Some(depth),
+          address = PolarizedPort(s"${portName}_addr", ActiveHigh),
+          clock = Some(PolarizedPort(s"${portName}_clk", PositiveEdge)),
+          chipEnable = Some(PolarizedPort(s"${portName}_en", ActiveHigh)),
+          writeEnable = Some(PolarizedPort(s"${portName}_wmode", ActiveHigh)),
+          maskPort = Some(PolarizedPort(s"${portName}_wmask", ActiveHigh)),
+          maskGran = maskGran,
+          input = Some(PolarizedPort(s"${portName}_wdata", ActiveHigh)),
+          output = Some(PolarizedPort(s"${portName}_rdata", ActiveHigh))
+        )
     }
   }
   def findSRAMCompiler(s: Option[Seq[mdf.macrolib.Macro]]): Option[mdf.macrolib.SRAMCompiler] = {
@@ -215,7 +208,7 @@ object Utils {
     )
   }
   def buildSRAMMacro(g: mdf.macrolib.SRAMGroup, d: Int, w: Int, vt: String): mdf.macrolib.SRAMMacro = {
-    return mdf.macrolib.SRAMMacro(
+    mdf.macrolib.SRAMMacro(
       makeName(g, d, w, vt),
       w,
       d,
@@ -241,9 +234,9 @@ object Utils {
     }
   }
 
-  def and(e1: Expression, e2: Expression) =
+  def and(e1: Expression, e2: Expression): DoPrim =
     DoPrim(PrimOps.And, Seq(e1, e2), Nil, e1.tpe)
-  def or(e1: Expression, e2: Expression) =
+  def or(e1: Expression, e2: Expression): DoPrim =
     DoPrim(PrimOps.Or, Seq(e1, e2), Nil, e1.tpe)
   def bits(e: Expression, high: BigInt, low: BigInt): Expression =
     DoPrim(PrimOps.Bits, Seq(e), Seq(high, low), UIntType(IntWidth(high - low + 1)))
@@ -251,7 +244,7 @@ object Utils {
   def cat(es: Seq[Expression]): Expression =
     if (es.size == 1) es.head
     else DoPrim(PrimOps.Cat, Seq(es.head, cat(es.tail)), Nil, UnknownType)
-  def not(e: Expression) =
+  def not(e: Expression): DoPrim =
     DoPrim(PrimOps.Not, Seq(e), Nil, e.tpe)
 
   // Convert a port to a FIRRTL expression, handling polarity along the way.

--- a/src/main/scala/barstools/macros/Utils.scala
+++ b/src/main/scala/barstools/macros/Utils.scala
@@ -55,8 +55,8 @@ class Macro(srcMacro: SRAMMacro) {
 
   val firrtlPorts: Seq[FirrtlMacroPort] = srcMacro.ports.map { new FirrtlMacroPort(_) }
 
-  val writers: Seq[FirrtlMacroPort] = firrtlPorts.filter(p => p.isWriter)
-  val readers: Seq[FirrtlMacroPort] = firrtlPorts.filter(p => p.isReader)
+  val writers:     Seq[FirrtlMacroPort] = firrtlPorts.filter(p => p.isWriter)
+  val readers:     Seq[FirrtlMacroPort] = firrtlPorts.filter(p => p.isReader)
   val readwriters: Seq[FirrtlMacroPort] = firrtlPorts.filter(p => p.isReadWriter)
 
   val sortedPorts: Seq[FirrtlMacroPort] = writers ++ readers ++ readwriters

--- a/src/test/scala/barstools/macros/CostFunction.scala
+++ b/src/test/scala/barstools/macros/CostFunction.scala
@@ -11,9 +11,9 @@ object TestMinWidthMetric extends CostMetric with CostMetricCompanion {
   // Smaller width = lower cost = favoured
   override def cost(mem: Macro, lib: Macro): Option[Double] = Some(lib.src.width)
 
-  override def commandLineParams = Map()
-  override def name = "TestMinWidthMetric"
-  override def construct(m: Map[String, String]) = TestMinWidthMetric
+  override def commandLineParams() = Map()
+  override def name() = "TestMinWidthMetric"
+  override def construct(m: Map[String, String]): CostMetric = TestMinWidthMetric
 }
 
 /** Test that cost metric selection is working. */
@@ -25,7 +25,7 @@ class SelectCostMetric extends MacroCompilerSpec with HasSRAMGenerator {
   // Cost metrics must be registered for them to work with the command line.
   CostMetric.registerCostMetric(TestMinWidthMetric)
 
-  override val costMetric = Some(TestMinWidthMetric)
+  override val costMetric: Option[CostMetric] = Some(TestMinWidthMetric)
 
   val libSRAMs = Seq(
     SRAMMacro(

--- a/src/test/scala/barstools/macros/Functional.scala
+++ b/src/test/scala/barstools/macros/Functional.scala
@@ -1,5 +1,6 @@
 package barstools.macros
 
+import firrtl.ir.Circuit
 import firrtl_interpreter.InterpretiveTester
 
 // Functional tests on memory compiler outputs.
@@ -10,8 +11,8 @@ class SynchronousReadAndWrite extends MacroCompilerSpec with HasSRAMGenerator wi
   override lazy val memDepth = BigInt(2048)
   override lazy val libDepth = BigInt(1024)
 
-  compile(mem, lib, v, true)
-  val result = execute(mem, lib, true)
+  compile(mem, lib, v, synflops = true)
+  val result: Circuit = execute(mem, lib, synflops = true)
 
   it should "run with InterpretedTester" in {
     pending // Enable this when https://github.com/freechipsproject/firrtl-interpreter/pull/88 is snapshot-published
@@ -70,8 +71,8 @@ class DontReadCombinationally extends MacroCompilerSpec with HasSRAMGenerator wi
   override lazy val memDepth = BigInt(2048)
   override lazy val libDepth = BigInt(1024)
 
-  compile(mem, lib, v, true)
-  val result = execute(mem, lib, true)
+  compile(mem, lib, v, synflops = true)
+  val result: Circuit = execute(mem, lib, synflops = true)
 
   it should "run with InterpretedTester" in {
     pending // Enable this when https://github.com/freechipsproject/firrtl-interpreter/pull/88 is snapshot-published

--- a/src/test/scala/barstools/macros/Masks.scala
+++ b/src/test/scala/barstools/macros/Masks.scala
@@ -23,9 +23,9 @@ class Masks_FourTypes_NonMaskedMem_NonMaskedLib
     with HasSimpleWidthTestGenerator {
   override lazy val depth = BigInt(1024)
   override lazy val memWidth = 32
-  override lazy val memMaskGran = None
+  override lazy val memMaskGran: Option[Int] = None
   override lazy val libWidth = 8
-  override lazy val libMaskGran = None
+  override lazy val libMaskGran: Option[Int] = None
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -38,9 +38,9 @@ class Masks_FourTypes_NonMaskedMem_MaskedLib
     with HasSimpleWidthTestGenerator {
   override lazy val depth = BigInt(1024)
   override lazy val memWidth = 32
-  override lazy val memMaskGran = None
+  override lazy val memMaskGran: Option[Int] = None
   override lazy val libWidth = 8
-  override lazy val libMaskGran = Some(2)
+  override lazy val libMaskGran: Option[Int] = Some(2)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -53,9 +53,9 @@ class Masks_FourTypes_MaskedMem_NonMaskedLib
     with HasSimpleWidthTestGenerator {
   override lazy val depth = BigInt(1024)
   override lazy val memWidth = 32
-  override lazy val memMaskGran = Some(8)
+  override lazy val memMaskGran: Option[Int] = Some(8)
   override lazy val libWidth = 8
-  override lazy val libMaskGran = None
+  override lazy val libMaskGran: Option[Int] = None
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -68,9 +68,9 @@ class Masks_FourTypes_MaskedMem_NonMaskedLib_SmallerMaskGran
     with HasSimpleWidthTestGenerator {
   override lazy val depth = BigInt(1024)
   override lazy val memWidth = 32
-  override lazy val memMaskGran = Some(4)
+  override lazy val memMaskGran: Option[Int] = Some(4)
   override lazy val libWidth = 8
-  override lazy val libMaskGran = None
+  override lazy val libMaskGran: Option[Int] = None
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -83,9 +83,9 @@ class Masks_FourTypes_MaskedMem_MaskedLib
     with HasSimpleWidthTestGenerator {
   override lazy val depth = BigInt(1024)
   override lazy val memWidth = 32
-  override lazy val memMaskGran = Some(8)
+  override lazy val memMaskGran: Option[Int] = Some(8)
   override lazy val libWidth = 16
-  override lazy val libMaskGran = Some(4)
+  override lazy val libMaskGran: Option[Int] = Some(4)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -98,9 +98,9 @@ class Masks_FourTypes_MaskedMem_MaskedLib_SameMaskGran
     with HasSimpleWidthTestGenerator {
   override lazy val depth = BigInt(1024)
   override lazy val memWidth = 32
-  override lazy val memMaskGran = Some(8)
+  override lazy val memMaskGran: Option[Int] = Some(8)
   override lazy val libWidth = 16
-  override lazy val libMaskGran = Some(8)
+  override lazy val libMaskGran: Option[Int] = Some(8)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -113,9 +113,9 @@ class Masks_FourTypes_MaskedMem_MaskedLib_SmallerMaskGran
     with HasSimpleWidthTestGenerator {
   override lazy val depth = BigInt(1024)
   override lazy val memWidth = 64
-  override lazy val memMaskGran = Some(4)
+  override lazy val memMaskGran: Option[Int] = Some(4)
   override lazy val libWidth = 32
-  override lazy val libMaskGran = Some(8)
+  override lazy val libMaskGran: Option[Int] = Some(8)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -127,9 +127,9 @@ class Masks_FourTypes_MaskedMem_MaskedLib_SmallerMaskGran
 class Masks_BitMaskedMem_NonMaskedLib extends MacroCompilerSpec with HasSRAMGenerator with HasSimpleWidthTestGenerator {
   override lazy val depth = BigInt(1024)
   override lazy val memWidth = 16
-  override lazy val memMaskGran = Some(1)
+  override lazy val memMaskGran: Option[Int] = Some(1)
   override lazy val libWidth = 8
-  override lazy val libMaskGran = None
+  override lazy val libMaskGran: Option[Int] = None
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -144,8 +144,8 @@ class Masks_FPGAStyle_32_8
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 32
-  override lazy val memMaskGran = Some(32)
-  override lazy val libMaskGran = Some(8)
+  override lazy val memMaskGran: Option[Int] = Some(32)
+  override lazy val libMaskGran: Option[Int] = Some(8)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -160,8 +160,8 @@ class Masks_PowersOfTwo_8_1
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 64
-  override lazy val memMaskGran = Some(8)
-  override lazy val libMaskGran = Some(1)
+  override lazy val memMaskGran: Option[Int] = Some(8)
+  override lazy val libMaskGran: Option[Int] = Some(1)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -174,8 +174,8 @@ class Masks_PowersOfTwo_16_1
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 64
-  override lazy val memMaskGran = Some(16)
-  override lazy val libMaskGran = Some(1)
+  override lazy val memMaskGran: Option[Int] = Some(16)
+  override lazy val libMaskGran: Option[Int] = Some(1)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -188,8 +188,8 @@ class Masks_PowersOfTwo_32_1
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 64
-  override lazy val memMaskGran = Some(32)
-  override lazy val libMaskGran = Some(1)
+  override lazy val memMaskGran: Option[Int] = Some(32)
+  override lazy val libMaskGran: Option[Int] = Some(1)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -202,8 +202,8 @@ class Masks_PowersOfTwo_64_1
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 64
-  override lazy val memMaskGran = Some(64)
-  override lazy val libMaskGran = Some(1)
+  override lazy val memMaskGran: Option[Int] = Some(64)
+  override lazy val libMaskGran: Option[Int] = Some(1)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -218,8 +218,8 @@ class Masks_PowersOfTwo_32_4
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 128
-  override lazy val memMaskGran = Some(32)
-  override lazy val libMaskGran = Some(4)
+  override lazy val memMaskGran: Option[Int] = Some(32)
+  override lazy val libMaskGran: Option[Int] = Some(4)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -232,8 +232,8 @@ class Masks_PowersOfTwo_32_8
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 128
-  override lazy val memMaskGran = Some(32)
-  override lazy val libMaskGran = Some(8)
+  override lazy val memMaskGran: Option[Int] = Some(32)
+  override lazy val libMaskGran: Option[Int] = Some(8)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -246,8 +246,8 @@ class Masks_PowersOfTwo_8_8
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 128
-  override lazy val memMaskGran = Some(8)
-  override lazy val libMaskGran = Some(8)
+  override lazy val memMaskGran: Option[Int] = Some(8)
+  override lazy val libMaskGran: Option[Int] = Some(8)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -262,8 +262,8 @@ class Masks_IntegerMaskMultiple_20_10
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 20
-  override lazy val memMaskGran = Some(10)
-  override lazy val libMaskGran = Some(1)
+  override lazy val memMaskGran: Option[Int] = Some(10)
+  override lazy val libMaskGran: Option[Int] = Some(1)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -276,8 +276,8 @@ class Masks_IntegerMaskMultiple_21_7
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 21
-  override lazy val memMaskGran = Some(21)
-  override lazy val libMaskGran = Some(7)
+  override lazy val memMaskGran: Option[Int] = Some(21)
+  override lazy val libMaskGran: Option[Int] = Some(7)
 
   (it should "be enabled when non-power of two masks are supported").is(pending)
   //~ compileExecuteAndTest(mem, lib, v, output)
@@ -289,8 +289,8 @@ class Masks_IntegerMaskMultiple_21_21
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 21
-  override lazy val memMaskGran = Some(21)
-  override lazy val libMaskGran = Some(1)
+  override lazy val memMaskGran: Option[Int] = Some(21)
+  override lazy val libMaskGran: Option[Int] = Some(1)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -303,8 +303,8 @@ class Masks_IntegerMaskMultiple_84_21
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 84
-  override lazy val memMaskGran = Some(21)
-  override lazy val libMaskGran = Some(1)
+  override lazy val memMaskGran: Option[Int] = Some(21)
+  override lazy val libMaskGran: Option[Int] = Some(1)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -317,8 +317,8 @@ class Masks_IntegerMaskMultiple_92_23
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 92
-  override lazy val memMaskGran = Some(23)
-  override lazy val libMaskGran = Some(1)
+  override lazy val memMaskGran: Option[Int] = Some(23)
+  override lazy val libMaskGran: Option[Int] = Some(1)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -331,8 +331,8 @@ class Masks_IntegerMaskMultiple_117_13
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 117
-  override lazy val memMaskGran = Some(13)
-  override lazy val libMaskGran = Some(1)
+  override lazy val memMaskGran: Option[Int] = Some(13)
+  override lazy val libMaskGran: Option[Int] = Some(1)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -345,8 +345,8 @@ class Masks_IntegerMaskMultiple_160_20
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 160
-  override lazy val memMaskGran = Some(20)
-  override lazy val libMaskGran = Some(1)
+  override lazy val memMaskGran: Option[Int] = Some(20)
+  override lazy val libMaskGran: Option[Int] = Some(1)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -359,8 +359,8 @@ class Masks_IntegerMaskMultiple_184_23
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 184
-  override lazy val memMaskGran = Some(23)
-  override lazy val libMaskGran = Some(1)
+  override lazy val memMaskGran: Option[Int] = Some(23)
+  override lazy val libMaskGran: Option[Int] = Some(1)
 
   it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
@@ -375,8 +375,8 @@ class Masks_NonIntegerMaskMultiple_32_3
     with HasSimpleDepthTestGenerator
     with MasksTestSettings {
   override lazy val width = 32
-  override lazy val memMaskGran = Some(3)
-  override lazy val libMaskGran = Some(1)
+  override lazy val memMaskGran: Option[Int] = Some(3)
+  override lazy val libMaskGran: Option[Int] = Some(1)
 
   (it should "be enabled when non-power of two masks are supported").is(pending)
   //~ compileExecuteAndTest(mem, lib, v, output)

--- a/src/test/scala/barstools/macros/MultiPort.scala
+++ b/src/test/scala/barstools/macros/MultiPort.scala
@@ -8,10 +8,10 @@ class SplitWidth_2rw extends MacroCompilerSpec with HasSRAMGenerator with HasSim
 
   override lazy val depth = BigInt(1024)
   override lazy val memWidth = 64
-  override lazy val memMaskGran = Some(16)
+  override lazy val memMaskGran: Option[Int] = Some(16)
   override lazy val libWidth = 16
 
-  override def generateMemSRAM() = {
+  override def generateMemSRAM(): SRAMMacro = {
     SRAMMacro(
       name = mem_name,
       width = memWidth,
@@ -42,7 +42,7 @@ class SplitWidth_2rw extends MacroCompilerSpec with HasSRAMGenerator with HasSim
     )
   }
 
-  override def generateLibSRAM() = {
+  override def generateLibSRAM(): SRAMMacro = {
     SRAMMacro(
       name = lib_name,
       width = libWidth,
@@ -71,16 +71,20 @@ class SplitWidth_2rw extends MacroCompilerSpec with HasSRAMGenerator with HasSim
     )
   }
 
-  override def generateHeaderPorts() = {
-    generateReadWriteHeaderPort("portA", true, Some(memMaskBits)) + "\n" + generateReadWriteHeaderPort(
+  override def generateHeaderPorts(): String = {
+    generateReadWriteHeaderPort("portA", readEnable = true, Some(memMaskBits)) + "\n" + generateReadWriteHeaderPort(
       "portB",
-      true,
+      readEnable = true,
       Some(memMaskBits)
     )
   }
 
-  override def generateFooterPorts() = {
-    generateReadWriteFooterPort("portA", true, None) + "\n" + generateReadWriteFooterPort("portB", true, None)
+  override def generateFooterPorts(): String = {
+    generateReadWriteFooterPort("portA", readEnable = true, None) + "\n" + generateReadWriteFooterPort(
+      "portB",
+      readEnable = true,
+      None
+    )
   }
 
   override def generateBody() =
@@ -151,10 +155,10 @@ class SplitWidth_1r_1w extends MacroCompilerSpec with HasSRAMGenerator with HasS
 
   override lazy val depth = BigInt(1024)
   override lazy val memWidth = 64
-  override lazy val memMaskGran = Some(16)
+  override lazy val memMaskGran: Option[Int] = Some(16)
   override lazy val libWidth = 16
 
-  override def generateMemSRAM() = {
+  override def generateMemSRAM(): SRAMMacro = {
     SRAMMacro(
       name = mem_name,
       width = memWidth,
@@ -167,7 +171,6 @@ class SplitWidth_1r_1w extends MacroCompilerSpec with HasSRAMGenerator with HasS
           Some(memDepth),
           maskGran = memMaskGran,
           write = false,
-          writeEnable = false,
           read = true,
           readEnable = true
         ),
@@ -178,14 +181,13 @@ class SplitWidth_1r_1w extends MacroCompilerSpec with HasSRAMGenerator with HasS
           maskGran = memMaskGran,
           write = true,
           writeEnable = true,
-          read = false,
-          readEnable = false
+          read = false
         )
       )
     )
   }
 
-  override def generateLibSRAM() = {
+  override def generateLibSRAM(): SRAMMacro = {
     SRAMMacro(
       name = lib_name,
       width = libWidth,
@@ -197,24 +199,15 @@ class SplitWidth_1r_1w extends MacroCompilerSpec with HasSRAMGenerator with HasS
           libWidth,
           libDepth,
           write = false,
-          writeEnable = false,
           read = true,
           readEnable = true
         ),
-        generateTestPort(
-          "portB",
-          libWidth,
-          libDepth,
-          write = true,
-          writeEnable = true,
-          read = false,
-          readEnable = false
-        )
+        generateTestPort("portB", libWidth, libDepth, write = true, writeEnable = true, read = false)
       )
     )
   }
 
-  override def generateHeaderPorts() = {
+  override def generateHeaderPorts(): String = {
     generatePort(
       "portA",
       mem_addr_width,
@@ -237,7 +230,7 @@ class SplitWidth_1r_1w extends MacroCompilerSpec with HasSRAMGenerator with HasS
       )
   }
 
-  override def generateFooterPorts() = {
+  override def generateFooterPorts(): String = {
     generatePort(
       "portA",
       lib_addr_width,
@@ -310,12 +303,12 @@ class SplitWidth_2rw_differentMasks extends MacroCompilerSpec with HasSRAMGenera
 
   override lazy val depth = BigInt(1024)
   override lazy val memWidth = 64
-  override lazy val memMaskGran = Some(16)
+  override lazy val memMaskGran: Option[Int] = Some(16)
   override lazy val libWidth = 16
 
   lazy val memMaskGranB = 8 // these generators are run at constructor time
 
-  override def generateMemSRAM() = {
+  override def generateMemSRAM(): SRAMMacro = {
     SRAMMacro(
       name = mem_name,
       width = memWidth,
@@ -346,7 +339,7 @@ class SplitWidth_2rw_differentMasks extends MacroCompilerSpec with HasSRAMGenera
     )
   }
 
-  override def generateLibSRAM() = {
+  override def generateLibSRAM(): SRAMMacro = {
     SRAMMacro(
       name = lib_name,
       width = libWidth,
@@ -375,16 +368,20 @@ class SplitWidth_2rw_differentMasks extends MacroCompilerSpec with HasSRAMGenera
     )
   }
 
-  override def generateHeaderPorts() = {
-    generateReadWriteHeaderPort("portA", true, Some(memMaskBits)) + "\n" + generateReadWriteHeaderPort(
+  override def generateHeaderPorts(): String = {
+    generateReadWriteHeaderPort("portA", readEnable = true, Some(memMaskBits)) + "\n" + generateReadWriteHeaderPort(
       "portB",
-      true,
+      readEnable = true,
       Some(memWidth / memMaskGranB)
     )
   }
 
-  override def generateFooterPorts() = {
-    generateReadWriteFooterPort("portA", true, None) + "\n" + generateReadWriteFooterPort("portB", true, None)
+  override def generateFooterPorts(): String = {
+    generateReadWriteFooterPort("portA", readEnable = true, None) + "\n" + generateReadWriteFooterPort(
+      "portB",
+      readEnable = true,
+      None
+    )
   }
 
   override def generateBody() =

--- a/src/test/scala/barstools/macros/SRAMCompiler.scala
+++ b/src/test/scala/barstools/macros/SRAMCompiler.scala
@@ -1,7 +1,9 @@
 package barstools.macros
 
+import mdf.macrolib
+
 class SRAMCompiler extends MacroCompilerSpec with HasSRAMGenerator with HasSimpleWidthTestGenerator {
-  val compiler = generateSRAMCompiler("awesome", "A")
+  val compiler: macrolib.SRAMCompiler = generateSRAMCompiler("awesome", "A")
   val verilog = s"v-SRAMCompiler.v"
   override lazy val depth = BigInt(16)
   override lazy val memWidth = 8
@@ -15,5 +17,5 @@ class SRAMCompiler extends MacroCompilerSpec with HasSRAMGenerator with HasSimpl
 
   writeToMem(mem, Seq(generateSRAM("mymem", "X", 8, 16)))
 
-  compileExecuteAndTest(mem, Some(lib), verilog, output = output, false, true)
+  compileExecuteAndTest(mem, Some(lib), verilog, output = output, useCompiler = true)
 }

--- a/src/test/scala/barstools/macros/SpecificExamples.scala
+++ b/src/test/scala/barstools/macros/SpecificExamples.scala
@@ -1,7 +1,8 @@
 // See LICENSE for license details.
 package barstools.macros
 
-import mdf.macrolib._
+import firrtl.FileUtils
+import mdf.macrolib.{Constant, MacroExtraPort, SRAMMacro}
 
 // Specific one-off tests to run, not created by a generator.
 
@@ -17,7 +18,7 @@ class GenerateSomeVerilog extends MacroCompilerSpec with HasSRAMGenerator with H
   }
 
   it should "generate non-empty verilog" in {
-    val verilog = scala.io.Source.fromFile(vPrefix + "/" + v).getLines().mkString("\n")
+    val verilog = FileUtils.getText(vPrefix + "/" + v)
     verilog.isEmpty shouldBe false
   }
 }
@@ -29,7 +30,7 @@ class WriteEnableTest extends MacroCompilerSpec with HasSRAMGenerator {
 
   override val libPrefix = "src/test/resources"
 
-  val memSRAMs = mdf.macrolib.Utils
+  val memSRAMs: Seq[mdf.macrolib.Macro] = mdf.macrolib.Utils
     .readMDFFromString("""
 [ {
   "type" : "sram",
@@ -53,7 +54,7 @@ class WriteEnableTest extends MacroCompilerSpec with HasSRAMGenerator {
   } ],
   "family" : "1rw"
 } ]
-""").getOrElse(List())
+""").getOrElse(Seq())
 
   writeToMem(mem, memSRAMs)
 
@@ -101,7 +102,7 @@ class MaskPortTest extends MacroCompilerSpec with HasSRAMGenerator {
 
   override val libPrefix = "src/test/resources"
 
-  val memSRAMs = mdf.macrolib.Utils
+  val memSRAMs: Seq[mdf.macrolib.Macro] = mdf.macrolib.Utils
     .readMDFFromString("""
 [ {
   "type" : "sram",
@@ -175,7 +176,7 @@ circuit cc_dir_ext :
     defname = fake_mem
 """
 
-  it should "compile, exectue, and test" in {
+  it should "compile, execute, and test" in {
     compileExecuteAndTest(mem, lib, v, output)
   }
 }
@@ -187,7 +188,7 @@ class BOOMTest extends MacroCompilerSpec with HasSRAMGenerator {
 
   override val libPrefix = "src/test/resources"
 
-  val memSRAMs = mdf.macrolib.Utils
+  val memSRAMs: Seq[mdf.macrolib.Macro] = mdf.macrolib.Utils
     .readMDFFromString("""
 [ {
   "type" : "sram",
@@ -1461,7 +1462,7 @@ class RocketChipTest extends MacroCompilerSpec with HasSRAMGenerator {
     )
   )
 
-  val memSRAMs = mdf.macrolib.Utils
+  val memSRAMs: Seq[mdf.macrolib.Macro] = mdf.macrolib.Utils
     .readMDFFromString("""
 [
   {

--- a/src/test/scala/barstools/tapeout/transforms/GenerateSpec.scala
+++ b/src/test/scala/barstools/tapeout/transforms/GenerateSpec.scala
@@ -17,7 +17,7 @@ class BlackBoxInverter extends ExtModule {
   val out = IO(Output(Bool()))
 }
 
-class GenerateExampleModule extends MultiIOModule {
+class GenerateExampleModule extends Module {
   val in = IO(Input(Bool()))
   val out = IO(Output(Bool()))
 
@@ -30,7 +30,7 @@ class GenerateExampleModule extends MultiIOModule {
   out := reg
 }
 
-class ToBeMadeExternal extends MultiIOModule {
+class ToBeMadeExternal extends Module {
   val in = IO(Input(Bool()))
   val out = IO(Output(Bool()))
 
@@ -39,7 +39,7 @@ class ToBeMadeExternal extends MultiIOModule {
   out := reg
 }
 
-class GenerateExampleTester extends MultiIOModule {
+class GenerateExampleTester extends Module {
   val success = IO(Output(Bool()))
 
   val mod = Module(new GenerateExampleModule)


### PR DESCRIPTION
- Fixed up all warnings in barstools macros package
- mostly public method return types
- removed lot's of extraneous parens and braces
- Made code cleaner using more explicit macros
- Fixed warnings in 2.13 that will likely turn into errors in future