### PR TITLE
avoid collision with new firrtl.Utils.and

### DIFF
--- a/macros/src/main/scala/barstools/macros/MacroCompiler.scala
+++ b/macros/src/main/scala/barstools/macros/MacroCompiler.scala
@@ -8,7 +8,7 @@
 package barstools.macros
 
 import barstools.macros.Utils._
-import firrtl.Utils._
+import firrtl.Utils.{BoolType, one, zero}
 import firrtl.annotations._
 import firrtl.ir._
 import firrtl.stage.{FirrtlSourceAnnotation, FirrtlStage, Forms, OutputFileAnnotation, RunFirrtlTransformAnnotation}

--- a/macros/src/main/scala/barstools/macros/SynFlops.scala
+++ b/macros/src/main/scala/barstools/macros/SynFlops.scala
@@ -3,7 +3,7 @@
 package barstools.macros
 
 import barstools.macros.Utils._
-import firrtl.Utils._
+import firrtl.Utils.{min, one, zero}
 import firrtl._
 import firrtl.ir._
 import firrtl.passes.MemPortUtils.memPortField


### PR DESCRIPTION
explicitly list imports from firrtl.Utils because barstools.macros.Utils
defines an 'and' function that will conflict with the newly added firrtl.Utils.and