### PR TITLE
Remove sbt subproject "tapeout"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Barstools
 
 ![Test](https://github.com/freechipsproject/ucb-bar/barstools/Test/badge.svg)
 
-**Barstools** is a coolection of useful utilities for BAR projects
+**Barstools** is a collection of useful utilities for BAR projects
 
 Passes/Transforms that could be useful if added here:
 * Check that a module was de-duplicated. Useful for MIM CAD flows and currently done in python.
@@ -18,16 +18,13 @@ Example Usage:
 ```
 sbt
 > compile
-> project tapeout
 > runMain barstools.tapeout.transforms.GenerateTop -i <myfile>.fir -o <myfile>.v --syn-top <mysyntop> --harness-top <myharnesstop>
 ```
 Building the macro compiler JAR:
 ```
 $ sbt
 [...]
-[info] Set current project to root (in build file:/mnt/data/dev/barstools_pcad/)
-> project macros
-[info] Set current project to macros (in build file:/mnt/data/dev/barstools_pcad/)
+[info] Set current project to tapeout (in build file:/mnt/data/dev/barstools_pcad/)
 > assembly
 [...]
 [info] SHA-1: 77d4c759c825fd0ea93dfec26dbbb649f6cd5c89

--- a/build.sbt
+++ b/build.sbt
@@ -5,39 +5,26 @@ val defaultVersions = Map(
   "chisel-iotesters" -> "2.5-SNAPSHOT"
 )
 
-lazy val commonSettings = Seq(
-  organization := "edu.berkeley.cs",
-  version := "0.4-SNAPSHOT",
-  scalaVersion := "2.12.13",
-  crossScalaVersions := Seq("2.12.13", "2.13.6"),
-  scalacOptions := Seq("-deprecation", "-feature", "-language:reflectiveCalls"),
-  libraryDependencies ++= Seq("chisel3","chisel-iotesters").map {
-    dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
-  },
-  libraryDependencies ++= Seq(
-    "com.typesafe.play" %% "play-json" % "2.9.2",
-    "org.scalatest" %% "scalatest" % "3.2.9" % "test",
-    "org.apache.logging.log4j" % "log4j-api" % "2.11.2",
-    "org.apache.logging.log4j" % "log4j-core" % "2.11.2"
-  ),
-  resolvers ++= Seq(
-    Resolver.sonatypeRepo("snapshots"),
-    Resolver.sonatypeRepo("releases"),
-    Resolver.mavenLocal
-  )
+organization := "edu.berkeley.cs"
+version := "0.4-SNAPSHOT"
+name := "tapeout"
+scalaVersion := "2.12.13"
+crossScalaVersions := Seq("2.12.13", "2.13.6")
+scalacOptions := Seq("-deprecation", "-feature", "-language:reflectiveCalls")
+Test / scalacOptions ++= Seq("-language:reflectiveCalls")
+fork := true
+mainClass := Some("barstools.macros.MacroCompiler")
+libraryDependencies ++= Seq("chisel3","chisel-iotesters").map {
+  dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep))
+}
+libraryDependencies ++= Seq(
+  "com.typesafe.play" %% "play-json" % "2.9.2",
+  "org.scalatest" %% "scalatest" % "3.2.9" % "test",
+  "org.apache.logging.log4j" % "log4j-api" % "2.11.2",
+  "org.apache.logging.log4j" % "log4j-core" % "2.11.2"
 )
-
-//disablePlugins(sbtassembly.AssemblyPlugin)
-//
-//enablePlugins(sbtassembly.AssemblyPlugin)
-
-lazy val tapeout = (project in file("."))
-  .settings(commonSettings)
-  .settings(scalacOptions in Test ++= Seq("-language:reflectiveCalls"))
-  .settings(fork := true)
-  .settings(
-    mainClass := Some("barstools.macros.MacroCompiler")
-  )
-  .enablePlugins(sbtassembly.AssemblyPlugin)
-
-//lazy val root = (project in file(".")).aggregate(tapeout)
+resolvers ++= Seq(
+  Resolver.sonatypeRepo("snapshots"),
+  Resolver.sonatypeRepo("releases"),
+  Resolver.mavenLocal
+)

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 // See LICENSE for license details.
 
 val defaultVersions = Map(
-  "chisel3" -> "3.5-SNAPSHOT",
-  "chisel-iotesters" -> "2.5-SNAPSHOT"
+  "chisel3" -> "3.5.1",
+  "chisel-iotesters" -> "2.5.1"
 )
 
 organization := "edu.berkeley.cs"

--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,7 @@ libraryDependencies ++= Seq(
   "org.apache.logging.log4j" % "log4j-api" % "2.11.2",
   "org.apache.logging.log4j" % "log4j-core" % "2.11.2"
 )
+addCompilerPlugin("edu.berkeley.cs" % "chisel3-plugin" % defaultVersions("chisel3") cross CrossVersion.full)
 resolvers ++= Seq(
   Resolver.sonatypeRepo("snapshots"),
   Resolver.sonatypeRepo("releases"),


### PR DESCRIPTION
Now barstools should be easier to compose in multi-project sbt projects, such as Chipyard.

Resolves ucb-bar/barstools#117.

Differences between this setup and the existing one:

- Removed `enablePlugins(sbtassembly.AssemblyPlugin)`. I think that since `sbt-assembly` is in `project/plugins.sbt`, this shouldn't be required. I was able to run `sbt assembly`, so that seems fine.
- Added `name := "tapeout"`, so the project name is `tapeout` when you enter an `sbt` console.

Everything else _should_ be preserved from the existing setup.