### PR TITLE
Dump per macro verilog (overridden by final verilog output)

### DIFF
--- a/src/main/scala/barstools/macros/MacroCompiler.scala
+++ b/src/main/scala/barstools/macros/MacroCompiler.scala
@@ -911,6 +911,7 @@ object MacroCompiler extends App {
               .execute(
                 Array.empty,
                 Seq(
+                  OutputFileAnnotation(params.get(Verilog).get),
                   RunFirrtlTransformAnnotation(new VerilogEmitter),
                   EmitCircuitAnnotation(classOf[VerilogEmitter]),
                   FirrtlSourceAnnotation(circuit.serialize)
@@ -922,6 +923,7 @@ object MacroCompiler extends App {
               .value
           }
           .mkString("\n")
+
         val verilogWriter = new FileWriter(new File(params.get(Verilog).get))
         verilogWriter.write(verilog)
         verilogWriter.close()


### PR DESCRIPTION
Currently, there are N verilog files emitted where the `.jar` is invoked since there is no `OutputFileAnnotation` (see misc. Verilog files dumped in Chipyard at the top-level everytime there is a compile). This reuses the output Verilog file that we want to dump the combined Verilog into so that it is used as a temp. file that everything is written to.