### PR TITLE
Update deprecated APIs to prepare for Chisel 5

### DIFF
--- a/iocell/src/main/scala/barstools/iocell/chisel/IOCell.scala
+++ b/iocell/src/main/scala/barstools/iocell/chisel/IOCell.scala
@@ -3,8 +3,9 @@
 package barstools.iocell.chisel
 
 import chisel3._
-import chisel3.util.{Cat, HasBlackBoxResource, HasBlackBoxInline}
-import chisel3.experimental.{Analog, BaseModule, DataMirror, IO}
+import chisel3.util.{Cat, HasBlackBoxInline}
+import chisel3.reflect.DataMirror
+import chisel3.experimental.{Analog, BaseModule}
 
 // The following four IO cell bundle types are bare-minimum functional connections
 // for modeling 4 different IO cell scenarios. The intention is that the user


### PR DESCRIPTION
- `IO` was moved from `chisel3.experimental` to `chisel3`
- `DataMirror` was moved from `chisel3.experimental` to `chisel3.reflect`